### PR TITLE
Firebird appears to pad the short as if it was a full int, thus firebirdsql returns wrong value.

### DIFF
--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -174,7 +174,7 @@ func (x *xSQLVAR) value(raw_value []byte) (v interface{}, err error) {
 			v = bytes.NewBuffer(raw_value).String()
 		}
 	case SQL_TYPE_SHORT:
-		i16 := bytes_to_bint16(raw_value)
+		i16 := int16(bytes_to_bint32(raw_value))
 		if x.sqlscale > 0 {
 			v = int64(i16) * int64(math.Pow10(x.sqlscale))
 		} else if x.sqlscale < 0 {


### PR DESCRIPTION
If the stored value was '1' then the old conversion will return '0', as the raw_value array is [0 0 0 1].

I referenced: http://sourceforge.net/p/firebird/code/HEAD/tree/client-java/trunk/src/main/org/firebirdsql/gds/XSQLVAR.java#l171
to see how they parse out a short value.
