### PR TITLE
Fix storage and retrieval of fractional seconds.

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -311,6 +311,53 @@ func TestRole(t *testing.T) {
 	}
 }
 
+func TestInsertTimestamp(t *testing.T) {
+	const (
+		sqlSchema = "CREATE TABLE TEST (VAL1 TIMESTAMP, VAL2 TIMESTAMP, VAL3 TIMESTAMP, VAL4 TIMESTAMP);"
+		sqlInsert = "INSERT INTO TEST (VAL1, VAL2, VAL3, VAL4) VALUES (?, ?, ?, '2015/2/9 19:25:50.7405');"
+		sqlSelect = "SELECT * FROM TEST;"
+	)
+
+	conn, err := sql.Open("firebirdsql_createdb", "sysdba:masterkey@localhost:3050/tmp/go_test_timestamp.fdb")
+	if err != nil {
+		t.Fatalf("Error creating: %v", err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Exec(sqlSchema)
+	if err != nil {
+		t.Fatalf("Error creating schema: %v", err)
+	}
+
+	dt1 := time.Date(2015, 2, 9, 19, 25, 50, 740500000, time.UTC)
+	dt2 := "2015/2/9 19:25:50.7405"
+	dt3 := "2015-2-9 19:25:50.7405"
+
+	if _, err = conn.Exec(sqlInsert, dt1, dt2, dt3); err != nil {
+		t.Fatalf("Error executing insert: %s", err)
+	}
+
+	var rt1, rt2, rt3, rt4 time.Time
+
+	err = conn.QueryRow(sqlSelect).Scan(&rt1, &rt2, &rt3, &rt4)
+	if err != nil {
+		t.Fatalf("Unexpected error in select: %s", err)
+	}
+
+	if rt1 != dt1 {
+		t.Errorf("Expected <%v>, got <%v>", dt1, rt1)
+	}
+	if rt2 != dt1 {
+		t.Errorf("Expected <%v>, got <%v>", dt1, rt2)
+	}
+	if rt3 != dt1 {
+		t.Errorf("Expected <%v>, got <%v>", dt1, rt3)
+	}
+	if rt4 != dt1 {
+		t.Errorf("Expected <%v>, got <%v>", dt1, rt4)
+	}
+}
+
 /*
 func TestFB3(t *testing.T) {
 	conn, err := sql.Open("firebirdsql_createdb", "sysdba:masterkey@localhost:3050/tmp/go_test_fb3.fdb")

--- a/utils.go
+++ b/utils.go
@@ -187,7 +187,7 @@ func _convert_date(t time.Time) []byte {
 }
 
 func _convert_time(t time.Time) []byte {
-	v := (t.Hour()*3600+t.Minute()*60+t.Second())*10000 + t.Nanosecond()
+	v := (t.Hour()*3600+t.Minute()*60+t.Second())*10000 + t.Nanosecond()/100000
 	return bint32_to_bytes(int32(v))
 }
 

--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -140,7 +140,7 @@ func (x *xSQLVAR) _parseTime(raw_value []byte) (int, int, int, int) {
 	h := m / 60
 	m = m % 60
 	s = s % 60
-	return h, m, s, (n % 10000) * 100
+	return h, m, s, (n % 10000) * 100000
 }
 
 func (x *xSQLVAR) parseDate(raw_value []byte) time.Time {


### PR DESCRIPTION
This PR fixes the storage and retrieval of fractions of a second. Firebird stores timestamps in units of 1/10,000 second. Go time.Time stores fractions of a second in nanoseconds (1/1,000,000,000 second).