### PR TITLE
Insert []byte slices without formatting as Go %v formatted strings.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -275,6 +275,8 @@ func paramsToBlr(params []driver.Value, protocolVersion int32) ([]byte, []byte) 
 		case nil:
 			v = []byte{}
 			blr = []byte{14, 0, 0}
+		case []byte:
+			blr, v = _strToBlr(string(f))
 		default:
 			// can't convert directory
 			blr, v = _strToBlr(fmt.Sprintf("%v", f))


### PR DESCRIPTION
Inserting []byte{65, 66, 67} in a parameterized statement was inserting "[65 66 67]" instead of "ABC".