### PR TITLE
Corrected Request (test issue 39)

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -87,7 +87,9 @@ func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
 
 		if err == nil {
 			rows.currentChunkRow = chunk.Front()
-		}
+		} else {
+                	return
+                }        
 	}
 
 	if rows.currentChunkRow == nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -223,7 +223,7 @@ func TestIssue39(t *testing.T) {
 		t.Fatalf("'Dynamic SQL Error' is not occured.")
 	}
 	err = tx.Rollback()
-	if err == nil {
+	if err != nil {
 		t.Fatalf("broken transaction, but error is not occured.")
 	}
 }

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -834,6 +834,12 @@ func (p *wireProtocol) opFetchResponse(stmtHandle int32, transHandle int32, xsql
 		b, _ = p.recvPackets(4)
 	}
 	if bytes_to_bint32(b) != op_fetch_response {
+        	if bytes_to_bint32(b) == op_response {
+		        _, _, _, err := p._parse_op_response()
+			if err != nil {
+				return nil, false, err
+			}
+		}
 		return nil, false, errors.New("opFetchResponse:Internal Error")
 	}
 	b, err = p.recvPackets(8)


### PR DESCRIPTION
return correct error from rows.next
get ("eat") correct error in wireprotocol.go
correct test issue 39