### PR TITLE
Fix read and write when using wire encryption.

### DIFF
--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -94,7 +94,7 @@ func (c *wireChannel) Read(buf []byte) (n int, err error) {
 	if c.rc4reader != nil {
 		src := make([]byte, len(buf))
 		n, err = c.conn.Read(src)
-		c.rc4reader.XORKeyStream(buf, src)
+		c.rc4reader.XORKeyStream(buf, src[0:n])
 		return
 	}
 	return c.conn.Read(buf)

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -104,7 +104,15 @@ func (c *wireChannel) Write(buf []byte) (n int, err error) {
 	if c.rc4writer != nil {
 		dst := make([]byte, len(buf))
 		c.rc4writer.XORKeyStream(dst, buf)
-		n, err = c.conn.Write(dst)
+		written := 0
+		for written < len(buf) {
+			n, err = c.conn.Write(dst[written:])
+			if err != nil {
+				return
+			}
+			written += n
+		}
+		n = written
 	} else {
 		n, err = c.conn.Write(buf)
 	}


### PR DESCRIPTION
Read and write functions work correctly only until read reads less bytes than requested or write writes less bytes than requested. Read function fails because it decrypts whole read buffer which is only partially filled with valid data. Write function fails because it encrypts whole buffer, but sends only part of encrypted bytes.

These commits fix both issues.