### PR TITLE
Remove unnecessary fmt.Sprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+/.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
In wireprotocal.go lines like this:
`debugPrint(p, fmt.Sprintf("\trecvPackets():%v:%v", buf, err))`
have overhead for fmt.Sprintf call even debugPrint body commented.