### PR TITLE
Select with 21 fields always return empty resultset without any errors

### DIFF
--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -469,6 +469,7 @@ func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQL
 				// bytes_to_int(rbuf[4:4+l]) == col_len
 				next_index, err = p._parse_select_items(rbuf[4+ln:], xsqlda)
 			}
+			break
 		} else {
 			break
 		}


### PR DESCRIPTION
Select with 21 fields always return empty result without any errors.
Example: https://gist.github.com/bat22/5960fda6aa8a02d6a6284bf7e07237a9