### PR TITLE
Avoid intermediate allocations for wire protocol conversions

### DIFF
--- a/decode_speed_test.go
+++ b/decode_speed_test.go
@@ -1,0 +1,75 @@
+package firebirdsql
+
+import (
+	"database/sql"
+	"log"
+	"testing"
+)
+
+func BenchmarkRead(b *testing.B) {
+	b.StopTimer()
+	temppath := TempFileName("test_basic_")
+	conn, err := sql.Open("firebirdsql_createdb", "sysdba:masterkey@localhost:3050"+temppath)
+	query := `
+	CREATE TABLE PERFTEST (
+		A SMALLINT,
+		B INT,
+		C BIGINT,
+		D VARCHAR(255),
+		B1 INT,
+		B2 INT,
+		B3 INT,
+		B4 INT,
+		B5 INT,
+		B6 INT,
+		B7 INT,
+		B8 INT,
+		B9 INT,
+		B11 INT,
+		B12 INT,
+		B13 INT,
+		B14 INT,
+		B15 INT,
+		B16 INT,
+		B17 INT,
+		B18 INT,
+		B19 INT
+	);
+	`
+	_, err = conn.Exec(query)
+	if err != nil {
+		b.Error(err)
+		log.Fatal(err)
+	}
+
+	tx, err := conn.Begin()
+	if err != nil {
+		b.Error(err)
+	}
+
+	stmt, err := tx.Prepare("INSERT INTO PERFTEST (A,B,C,D,B1,B2,B3,B4,B5,B6,B7,B8,B9,B11,B12,B13,B14,B15,B16,B17,B18,B19) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
+	if err != nil {
+		b.Error(err)
+		log.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		stmt.Exec(i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i)
+	}
+	tx.Commit()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		rows, err := conn.Query("SELECT * FROM PERFTEST")
+		if err != nil {
+			b.Error(err)
+		}
+
+		var vals []interface{}
+
+		for rows.Next() {
+			rows.Scan(vals...)
+		}
+		rows.Close()
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -35,7 +35,7 @@ import (
 )
 
 func str_to_bytes(s string) []byte {
-	return bytes.NewBufferString(s).Bytes()
+	return []byte(s)
 }
 
 func int32_to_bytes(i32 int32) []byte {
@@ -66,49 +66,31 @@ func int16_to_bytes(i16 int16) []byte {
 	return bs
 }
 func bytes_to_str(b []byte) string {
-	return bytes.NewBuffer(b).String()
+	return string(b)
 }
 
 func bytes_to_bint32(b []byte) int32 {
-	var i32 int32
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.BigEndian, &i32)
-	return i32
+	return int32(binary.BigEndian.Uint32(b))
 }
 
 func bytes_to_int32(b []byte) int32 {
-	var i32 int32
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.LittleEndian, &i32)
-	return i32
+	return int32(binary.LittleEndian.Uint32(b))
 }
 
 func bytes_to_bint16(b []byte) int16 {
-	var i int16
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.BigEndian, &i)
-	return i
+	return int16(binary.BigEndian.Uint16(b))
 }
 
 func bytes_to_int16(b []byte) int16 {
-	var i int16
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.LittleEndian, &i)
-	return i
+	return int16(binary.LittleEndian.Uint16(b))
 }
 
 func bytes_to_bint64(b []byte) int64 {
-	var i int64
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.BigEndian, &i)
-	return i
+	return int64(binary.BigEndian.Uint64(b))
 }
 
 func bytes_to_int64(b []byte) int64 {
-	var i int64
-	buffer := bytes.NewBuffer(b)
-	binary.Read(buffer, binary.LittleEndian, &i)
-	return i
+	return int64(binary.LittleEndian.Uint64(b))
 }
 
 func xdrBytes(bs []byte) []byte {


### PR DESCRIPTION
utils.go performs a lot of intermediate buffer allocations for converting byte sequences to int32, etc. This results in a lot of unnecessary allocations which can pretty substantially slow down reads.

I added a small benchmark in decode_speed_test.go. It shows off the difference pretty clearly:

```
(master) $ go test -bench=. -run=XXnoMatch -count 5 -benchmem
goos: linux
goarch: amd64
pkg: github.com/nakagami/firebirdsql
BenchmarkRead-12            3000            565649 ns/op           65462 B/op       1398 allocs/op
BenchmarkRead-12            3000            593914 ns/op           65441 B/op       1398 allocs/op
BenchmarkRead-12            2000            582589 ns/op           65445 B/op       1398 allocs/op
BenchmarkRead-12            3000            579606 ns/op           65460 B/op       1398 allocs/op
BenchmarkRead-12            2000            603802 ns/op           65432 B/op       1398 allocs/op
PASS
ok      github.com/nakagami/firebirdsql 20.087s

>> Average 585112ns/row read

(perf-fixes) $ go test -bench=. -run=XXnoMatch -count 5 -benchmem
goos: linux
goarch: amd64
pkg: github.com/nakagami/firebirdsql
BenchmarkRead-12            3000            397414 ns/op           12872 B/op        156 allocs/op
BenchmarkRead-12            3000            384127 ns/op           12855 B/op        156 allocs/op
BenchmarkRead-12            3000            406941 ns/op           12857 B/op        156 allocs/op
BenchmarkRead-12            5000            430075 ns/op           12850 B/op        156 allocs/op
BenchmarkRead-12            3000            417873 ns/op           12844 B/op        156 allocs/op
PASS
ok      github.com/nakagami/firebirdsql 19.745s

>> Average 407286ns/row read
```

In this case, my synthetic benchmark runs about 43% faster just by removing the intermediate allocations. I have production DBs with several hundred integer columns, which saw ~300% speedups with this change.