### PR TITLE
ability to return date, time and timestamp in a casteable format

### DIFF
--- a/xsqlvar_test.go
+++ b/xsqlvar_test.go
@@ -1,0 +1,23 @@
+package firebirdsql
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDateTypes(t *testing.T) {
+	tz := time.Local
+	date := time.Date(1992, 1, 12, 4, 13, 22, 629*1000000, tz)
+
+	var expected = []string{"1992-01-12", "04:13:22.629", "1992-01-12 04:13:22.629"}
+	var sqlDateTypes = []int{SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP}
+
+	for i, sqltype := range sqlDateTypes {
+
+		casteableDate := parseDateType(date, sqltype)
+
+		if casteableDate != expected[i] {
+			t.Errorf("parse date to casteable date fail, expected %s returned %s", expected[i], casteableDate)
+		}
+	}
+}


### PR DESCRIPTION
Added new exported boolean variable called ReturnCasteableDate, if true then date types Date, Time and Timestamp are returned in casteable formats

Date: returned in format 2006-01-02
Time: returned in format 15:04:05.000
Timestamp: returned in format 2006-01-02 15:04:05.000