### PR TITLE
Add float64 encoding.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -210,6 +210,13 @@ func _int32ToBlr(i32 int32) ([]byte, []byte) {
 	return blr, v
 }
 
+func _float64ToBlr(v float64) ([]byte, []byte) {
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, v)
+	blr := []byte{27}
+	return blr, buf.Bytes()
+}
+
 func _bytesToBlr(v []byte) ([]byte, []byte) {
 	nbytes := len(v)
 	pad_length := ((4 - nbytes) & 3)

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -1286,6 +1286,8 @@ func (p *wireProtocol) paramsToBlr(transHandle int32, params []driver.Value, pro
 			blr, v = _int32ToBlr(f)
 		case int64:
 			blr, v = _int64ToBlr(int64(f))
+		case float64:
+			blr, v = _float64ToBlr(float64(f))
 		case time.Time:
 			if f.Year() == 0 {
 				blr, v = _timeToBlr(f)


### PR DESCRIPTION
This pull requests adds the ability to encode a float64 value in an executed statement.

Tested using a table that defines a field as double precision.
Without this change firebird stores a float64 value of '93.60000000000001' on an update/insert statement  as '93.59999999999999'.
My assumption is that firebird is converting the string to float with slightly different rules as Golang. With this change the driver is able to write the same binary float64 number as it reads.