### PR TITLE
update mathutil to support loong64 arch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/text v0.3.5
-	modernc.org/mathutil v1.4.1
+	modernc.org/mathutil v1.4.2-0.20220822142738-b13e5b564332
 )

--- a/go.sum
+++ b/go.sum
@@ -17,5 +17,5 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-modernc.org/mathutil v1.4.1 h1:ij3fYGe8zBF4Vu+g0oT7mB06r8sqGWKuJu1yXeR4by8=
-modernc.org/mathutil v1.4.1/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=
+modernc.org/mathutil v1.4.2-0.20220822142738-b13e5b564332 h1:TKGxwtHBlHsKAKIpQE7MEPGs0FFe+DeGNkrLi22sApk=
+modernc.org/mathutil v1.4.2-0.20220822142738-b13e5b564332/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=


### PR DESCRIPTION
only added the new build contraint for loong64 https://gitlab.com/cznic/mathutil/-/compare/v1.4.1...master