### PR TITLE
xsqlvar.go: fix varchar (VARYING) type display length

### DIFF
--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -145,7 +145,7 @@ type xSQLVAR struct {
 }
 
 func (x *xSQLVAR) ioLength() int {
-	if x.sqltype == SQL_TYPE_TEXT || x.sqltype == SQL_TYPE_VARYING {
+	if x.sqltype == SQL_TYPE_TEXT {
 		return x.sqllen
 	}
 	return xsqlvarTypeLength[x.sqltype]

--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -145,14 +145,14 @@ type xSQLVAR struct {
 }
 
 func (x *xSQLVAR) ioLength() int {
-	if x.sqltype == SQL_TYPE_TEXT {
+	if x.sqltype == SQL_TYPE_TEXT || x.sqltype == SQL_TYPE_VARYING {
 		return x.sqllen
 	}
 	return xsqlvarTypeLength[x.sqltype]
 }
 
 func (x *xSQLVAR) displayLength() int {
-	if x.sqltype == SQL_TYPE_TEXT {
+	if x.sqltype == SQL_TYPE_TEXT || x.sqltype == SQL_TYPE_VARYING {
 		return x.sqllen
 	}
 	return xsqlvarTypeDisplayLength[x.sqltype]


### PR DESCRIPTION
Length method of rows.ColumnTypes returns incorrect length (always -1) for VARCHAR (VARYING) type, while returning correct length for CHAR (TEXT) type. This patch fixes this. Applying change only to displayLength method seems to be sufficient, but I changed ioLength too (not sure if necessary).