### PR TITLE
feat: Add character encoding conversion function

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1222,6 +1222,39 @@ func TestGoIssue172(t *testing.T) {
 	require.NoError(t, rows.Close())
 }
 
+func TestKSC_5601(t *testing.T) {
+	testDsn := GetTestDSN("test_KSC_5601_") + "?charset=KSC_5601"
+	conn, err := sql.Open("firebirdsql_createdb", testDsn)
+	require.NoError(t, err)
+
+	query := `CREATE TABLE t (text CHAR(6))`
+	_, err = conn.Exec(query)
+	require.NoError(t, err)
+
+	_, err = conn.Exec("INSERT INTO t VALUES ('안녕하세요.')")
+	require.NoError(t, err)
+
+	rows, err := conn.Query("SELECT text FROM t")
+	require.NoError(t, err)
+
+	var text string
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&text))
+	assert.Equal(t, "안녕하세요.", text)
+	require.NoError(t, rows.Close())
+
+	_, err = conn.Exec("INSERT INTO t VALUES (?)", "안녕하세요.")
+	require.NoError(t, err)
+
+	rows, err = conn.Query("SELECT text FROM t")
+	require.NoError(t, err)
+
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&text))
+	assert.Equal(t, "안녕하세요.", text)
+	require.NoError(t, rows.Close())
+}
+
 func TestTimeoutQueryContextDuringScan(t *testing.T) {
 	testDsn := GetTestDSN("test_timeout_query_context_scan_")
 	conn, err := sql.Open("firebirdsql_createdb", testDsn)

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -33,6 +33,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
 	"math/big"
 	"net"
 	"os"
@@ -1388,6 +1393,7 @@ func (p *wireProtocol) paramsToBlr(transHandle int32, params []driver.Value, pro
 	for _, param := range params {
 		switch f := param.(type) {
 		case string:
+			f = p.encodeString(f)
 			b := str_to_bytes(f)
 			if len(b) < MAX_CHAR_LENGTH {
 				blr, v = _bytesToBlr(b)
@@ -1498,4 +1504,119 @@ func (p *wireProtocol) opCancel(kind int) error {
 	p.packInt(int32(kind))
 	_, err := p.sendPackets()
 	return err
+}
+
+func (p *wireProtocol) encodeString(str string) string {
+	switch p.charset {
+	case "OCTETS":
+		return str
+	case "UNICODE_FSS", "UTF8":
+		return str
+	case "SJIS_0208":
+		enc := japanese.ShiftJIS.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "EUCJ_0208":
+		enc := japanese.EUCJP.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_1":
+		enc := charmap.ISO8859_1.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_2":
+		enc := charmap.ISO8859_2.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_3":
+		enc := charmap.ISO8859_3.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_4":
+		enc := charmap.ISO8859_5.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_5":
+		enc := charmap.ISO8859_5.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_6":
+		enc := charmap.ISO8859_6.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_7":
+		enc := charmap.ISO8859_7.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_8":
+		enc := charmap.ISO8859_8.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_9":
+		enc := charmap.ISO8859_9.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "ISO8859_13":
+		enc := charmap.ISO8859_13.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "KSC_5601":
+		enc := korean.EUCKR.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1250":
+		enc := charmap.Windows1250.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1251":
+		enc := charmap.Windows1251.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1252":
+		enc := charmap.Windows1252.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1253":
+		enc := charmap.Windows1252.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1254":
+		enc := charmap.Windows1252.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "BIG_5":
+		enc := traditionalchinese.Big5.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "GB_2312":
+		enc := simplifiedchinese.HZGB2312.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1255":
+		enc := charmap.Windows1255.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1256":
+		enc := charmap.Windows1256.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1257":
+		enc := charmap.Windows1257.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "KOI8R":
+		enc := charmap.KOI8R.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "KOI8U":
+		enc := charmap.KOI8U.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	case "WIN1258":
+		enc := charmap.Windows1258.NewEncoder()
+		v, _ := enc.String(str)
+		return v
+	default:
+		return str // If the specified charset is not supported, return the input string without any modification or encoding.
+	}
 }

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -33,6 +33,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/kardianos/osext"
+	"gitlab.com/nyarla/go-crypt"
+	"golang.org/x/crypto/chacha20"
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/encoding/korean"
@@ -44,10 +47,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/kardianos/osext"
-	"gitlab.com/nyarla/go-crypt"
-	"golang.org/x/crypto/chacha20"
 	//"unsafe"
 )
 
@@ -226,7 +225,7 @@ func (p *wireProtocol) packBytes(b []byte) {
 }
 
 func (p *wireProtocol) packString(s string) {
-	p.buf = append(p.buf, xdrBytes([]byte(s))...)
+	p.buf = append(p.buf, xdrBytes([]byte(p.encodeString(s)))...)
 }
 
 func (p *wireProtocol) appendBytes(bs []byte) {

--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -310,122 +310,118 @@ func (x *xSQLVAR) parseString(raw_value []byte, charset string) interface{} {
 	if x.sqlsubtype == 1 { // OCTETS
 		return raw_value
 	}
-	if x.sqlsubtype == 0 {
-		switch charset {
-		case "OCTETS":
-			return raw_value
-		case "UNICODE_FSS", "UTF8":
-			return bytes.NewBuffer(raw_value).String()
-		case "SJIS_0208":
-			dec := japanese.ShiftJIS.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "EUCJ_0208":
-			dec := japanese.EUCJP.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_1":
-			dec := charmap.ISO8859_1.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_2":
-			dec := charmap.ISO8859_2.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_3":
-			dec := charmap.ISO8859_3.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_4":
-			dec := charmap.ISO8859_5.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_5":
-			dec := charmap.ISO8859_5.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_6":
-			dec := charmap.ISO8859_6.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_7":
-			dec := charmap.ISO8859_7.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_8":
-			dec := charmap.ISO8859_8.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_9":
-			dec := charmap.ISO8859_9.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "ISO8859_13":
-			dec := charmap.ISO8859_13.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "KSC_5601":
-			dec := korean.EUCKR.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1250":
-			dec := charmap.Windows1250.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1251":
-			dec := charmap.Windows1251.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1252":
-			dec := charmap.Windows1252.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1253":
-			dec := charmap.Windows1252.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1254":
-			dec := charmap.Windows1252.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "BIG_5":
-			dec := traditionalchinese.Big5.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "GB_2312":
-			dec := simplifiedchinese.HZGB2312.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1255":
-			dec := charmap.Windows1255.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1256":
-			dec := charmap.Windows1256.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1257":
-			dec := charmap.Windows1257.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "KOI8R":
-			dec := charmap.KOI8R.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "KOI8U":
-			dec := charmap.KOI8U.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		case "WIN1258":
-			dec := charmap.Windows1258.NewDecoder()
-			v, _ := dec.Bytes(raw_value)
-			return string(v)
-		default:
-			return bytes.NewBuffer(raw_value).String()
-		}
+	switch charset {
+	case "OCTETS":
+		return raw_value
+	case "UNICODE_FSS", "UTF8":
+		return bytes.NewBuffer(raw_value).String()
+	case "SJIS_0208":
+		dec := japanese.ShiftJIS.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "EUCJ_0208":
+		dec := japanese.EUCJP.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_1":
+		dec := charmap.ISO8859_1.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_2":
+		dec := charmap.ISO8859_2.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_3":
+		dec := charmap.ISO8859_3.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_4":
+		dec := charmap.ISO8859_5.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_5":
+		dec := charmap.ISO8859_5.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_6":
+		dec := charmap.ISO8859_6.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_7":
+		dec := charmap.ISO8859_7.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_8":
+		dec := charmap.ISO8859_8.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_9":
+		dec := charmap.ISO8859_9.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "ISO8859_13":
+		dec := charmap.ISO8859_13.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "KSC_5601":
+		dec := korean.EUCKR.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1250":
+		dec := charmap.Windows1250.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1251":
+		dec := charmap.Windows1251.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1252":
+		dec := charmap.Windows1252.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1253":
+		dec := charmap.Windows1252.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1254":
+		dec := charmap.Windows1252.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "BIG_5":
+		dec := traditionalchinese.Big5.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "GB_2312":
+		dec := simplifiedchinese.HZGB2312.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1255":
+		dec := charmap.Windows1255.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1256":
+		dec := charmap.Windows1256.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1257":
+		dec := charmap.Windows1257.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "KOI8R":
+		dec := charmap.KOI8R.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "KOI8U":
+		dec := charmap.KOI8U.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	case "WIN1258":
+		dec := charmap.Windows1258.NewDecoder()
+		v, _ := dec.Bytes(raw_value)
+		return string(v)
+	default:
+		return raw_value
 	}
-
-	return raw_value
 }
 
 func (x *xSQLVAR) value(raw_value []byte, timezone string, charset string) (v interface{}, err error) {


### PR DESCRIPTION
First, I apologize for the omission of test code in PR #176.
In this PR, I have added test code. I used for testing is Firebird SS 2.5.

## Changes
- Add a function to convert a given string to a specified character encoding
- Support various target character encodings (e.g., UTF-8, EUC-KR)