### PR TITLE
Fix panic in prepare when tx is nil

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -79,6 +79,9 @@ func (fc *firebirdsqlConn) Close() (err error) {
 }
 
 func (fc *firebirdsqlConn) prepare(ctx context.Context, query string) (driver.Stmt, error) {
+	if fc.tx == nil {
+		return nil, driver.ErrBadConn
+	}
 	if fc.tx.needBegin {
 		err := fc.tx.begin()
 		if err != nil {


### PR DESCRIPTION
Fixes #197.

When the connection is in an incorrect state (e.g. after a network error/timeout), fc.tx can become nil.
prepare() then panics on fc.tx.needBegin. Return driver.ErrBadConn so database/sql can drop the bad connection and retry.