### PR TITLE
Support READ COMMITTED + NOWAIT transactions (fail fast on lock conflicts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ param1, param2... are
 | wire_crypt | Enable wire data encryption or not. | true | For Firebird 3.0+ |
 | charset | Firebird Charecter Set | | |
 
+## Transactions: READ COMMITTED + NOWAIT
+
+Firebird supports `NOWAIT` transactions (lock conflicts return immediately instead of waiting).
+The standard `database/sql` `sql.TxOptions` doesn't have a knob for `NOWAIT`, so this driver exposes a driver-specific isolation level constant:
+
+```go
+tx, err := db.BeginTx(ctx, &sql.TxOptions{
+	Isolation: firebirdsql.LevelReadCommittedNoWait,
+})
+```
+
+This maps to a transaction TPB containing `READ COMMITTED`, `RECORD VERSION`, and `NOWAIT`.
+
 ## GORM for Firebird
 
 See https://github.com/flylink888/gorm-firebird

--- a/consts.go
+++ b/consts.go
@@ -542,6 +542,18 @@ const (
 	ISOLATION_LEVEL_REPEATABLE_READ
 	ISOLATION_LEVEL_SERIALIZABLE
 	ISOLATION_LEVEL_READ_COMMITED_RO
+	// NOWAIT variants (lock conflicts return immediately instead of waiting)
+	ISOLATION_LEVEL_READ_COMMITED_NOWAIT
+	ISOLATION_LEVEL_READ_COMMITED_RO_NOWAIT
+)
+
+// Driver-specific transaction isolation levels for database/sql.
+//
+// database/sql doesn't have a way to express Firebird's NOWAIT/LOCK TIMEOUT,
+// so this driver exposes a custom value for use in sql.TxOptions.Isolation.
+const (
+	// LevelReadCommittedNoWait starts a READ COMMITTED transaction with NOWAIT lock resolution.
+	LevelReadCommittedNoWait = 1000
 )
 
 // Event

--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,10 @@ func (e *ErrOpResponse) Error() string    { return fmt.Sprintf("Error op_respons
 
 var ErrOpSqlResponse = errors.New("Error op_sql_response")
 
+// ErrInvalidIsolationLevel is returned when an unsupported isolation level is requested.
+// This is an internal guard: normal code paths should only use supported levels.
+var ErrInvalidIsolationLevel = errors.New("invalid isolation level")
+
 type FbError struct {
 	GDSCodes []int
 	Message  string

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -24,10 +24,45 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package firebirdsql
 
 import (
+	"bytes"
 	"database/sql"
 	"testing"
 	"time"
 )
+
+func TestTPBForIsolationLevelReadCommittedNoWait(t *testing.T) {
+	tpb, err := tpbForIsolationLevel(ISOLATION_LEVEL_READ_COMMITED_NOWAIT)
+	if err != nil {
+		t.Fatalf("tpbForIsolationLevel(): %v", err)
+	}
+	want := []byte{
+		byte(isc_tpb_version3),
+		byte(isc_tpb_write),
+		byte(isc_tpb_nowait),
+		byte(isc_tpb_read_committed),
+		byte(isc_tpb_rec_version),
+	}
+	if !bytes.Equal(tpb, want) {
+		t.Fatalf("tpb mismatch\n got: %v\nwant: %v", tpb, want)
+	}
+}
+
+func TestTPBForIsolationLevelReadCommittedRONoWait(t *testing.T) {
+	tpb, err := tpbForIsolationLevel(ISOLATION_LEVEL_READ_COMMITED_RO_NOWAIT)
+	if err != nil {
+		t.Fatalf("tpbForIsolationLevel(): %v", err)
+	}
+	want := []byte{
+		byte(isc_tpb_version3),
+		byte(isc_tpb_read),
+		byte(isc_tpb_nowait),
+		byte(isc_tpb_read_committed),
+		byte(isc_tpb_rec_version),
+	}
+	if !bytes.Equal(tpb, want) {
+		t.Fatalf("tpb mismatch\n got: %v\nwant: %v", tpb, want)
+	}
+}
 
 func TestTransaction(t *testing.T) {
 	var n int


### PR DESCRIPTION
Firebird supports NOWAIT transactions (fail fast on lock conflicts). This is useful for async workers (pubsub/event handlers): when a row is locked, it's often better to get an error immediately and retry with backoff instead of blocking.

### Changes
- Add `firebirdsql.LevelReadCommittedNoWait` (driver-specific `sql.IsolationLevel`)
- Map it in `BeginTx` to a TPB with READ COMMITTED + RECORD VERSION + NOWAIT (and a RO variant)
- Add unit tests for TPB generation
- Document usage in README

### Usage
```go
tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: firebirdsql.LevelReadCommittedNoWait})
```

### Issue
Fixes #198
