### PR TITLE
fix: correct bind-aware TIME/TIMESTAMP encoding and lazy bind-metadata fetch

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -455,7 +455,8 @@ func TestInsertTimestamp(t *testing.T) {
 		t.Fatalf("Error creating table: %v", err)
 	}
 
-	dt1 := time.Date(2015, 2, 9, 19, 25, 50, 740500000, time.Local)
+	loc := time.FixedZone("UTC+9", 9*3600)
+	dt1 := time.Date(2015, 2, 9, 19, 25, 50, 740500000, loc)
 	dt2 := "2015/2/9 19:25:50.7405"
 	dt3 := "2015-2-9 19:25:50.7405"
 
@@ -470,18 +471,19 @@ func TestInsertTimestamp(t *testing.T) {
 		t.Fatalf("Unexpected error in select: %s", err)
 	}
 
-	if rt1 != dt1 {
-		t.Errorf("Expected <%v>, got <%v>", dt1, rt1)
+	// TIMESTAMP stores wall-clock values; compare components, not UTC instants,
+	// so the test is independent of the session timezone and TZ environment variable.
+	checkWallClock := func(label string, got time.Time) {
+		if got.Year() != dt1.Year() || got.Month() != dt1.Month() || got.Day() != dt1.Day() ||
+			got.Hour() != dt1.Hour() || got.Minute() != dt1.Minute() || got.Second() != dt1.Second() ||
+			got.Nanosecond() != dt1.Nanosecond() {
+			t.Errorf("%s: expected wall clock <%v>, got <%v>", label, dt1, got)
+		}
 	}
-	if rt2 != dt1 {
-		t.Errorf("Expected <%v>, got <%v>", dt1, rt2)
-	}
-	if rt3 != dt1 {
-		t.Errorf("Expected <%v>, got <%v>", dt1, rt3)
-	}
-	if rt4 != dt1 {
-		t.Errorf("Expected <%v>, got <%v>", dt1, rt4)
-	}
+	checkWallClock("VAL1", rt1)
+	checkWallClock("VAL2", rt2)
+	checkWallClock("VAL3", rt3)
+	checkWallClock("VAL4", rt4)
 	conn.Close()
 }
 
@@ -1585,4 +1587,47 @@ func TestAuth(t *testing.T) {
 	conn, err = sql.Open("firebirdsql", "notexisting:wrongpassword@localhost/employee")
 	err = conn.Ping()
 	assert.EqualError(t, err, "Your user name and password are not defined. Ask your database administrator to set up a Firebird login.\n")
+}
+
+func TestInsertTimeDateLocalWallClock(t *testing.T) {
+	conn, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_time_date_"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.Exec("CREATE TABLE test_td (d DATE, tm TIME, ts TIMESTAMP)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loc := time.FixedZone("UTC+9", 9*3600)
+	dt := time.Date(2024, 6, 15, 14, 30, 45, 0, loc)
+	tm := time.Date(0, 1, 1, 14, 30, 45, 0, loc) // matches the shape the driver returns when reading TIME columns (no date component)
+
+	if _, err = conn.Exec(
+		"INSERT INTO test_td (d, tm, ts) VALUES (?, ?, ?)",
+		dt, tm, dt,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var rd, rt, rts time.Time
+	if err = conn.QueryRow("SELECT d, tm, ts FROM test_td").Scan(&rd, &rt, &rts); err != nil {
+		t.Fatal(err)
+	}
+
+	// DATE: wall-clock date components must round-trip regardless of session timezone
+	if rd.Year() != 2024 || rd.Month() != time.June || rd.Day() != 15 {
+		t.Errorf("DATE wall clock mismatch: got %v", rd)
+	}
+	// TIME: wall-clock time-of-day must round-trip
+	if rt.Hour() != 14 || rt.Minute() != 30 || rt.Second() != 45 {
+		t.Errorf("TIME wall clock mismatch: got %v", rt)
+	}
+	// TIMESTAMP: both date and time components must round-trip
+	if rts.Year() != 2024 || rts.Month() != time.June || rts.Day() != 15 ||
+		rts.Hour() != 14 || rts.Minute() != 30 || rts.Second() != 45 {
+		t.Errorf("TIMESTAMP wall clock mismatch: got %v", rts)
+	}
+	conn.Close()
 }

--- a/statement.go
+++ b/statement.go
@@ -85,7 +85,28 @@ func (stmt *firebirdsqlStmt) sendOpCancel(ctx context.Context, done chan struct{
 	}
 }
 
+// ensureInputXsqlda fetches bind-parameter metadata on first execute with args.
+// It records the attempt by leaving inputXsqlda as a non-nil empty slice when the
+// server returns no metadata, so we don't re-issue the info request on every call.
+func (stmt *firebirdsqlStmt) ensureInputXsqlda(args []driver.Value) error {
+	if len(args) == 0 || stmt.inputXsqlda != nil {
+		return nil
+	}
+	xs, err := stmt.fc.wp._fetchBindXsqlda(stmt.stmtHandle)
+	if err != nil {
+		return err
+	}
+	if xs == nil {
+		xs = []xSQLVAR{}
+	}
+	stmt.inputXsqlda = xs
+	return nil
+}
+
 func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (result driver.Result, err error) {
+	if err = stmt.ensureInputXsqlda(args); err != nil {
+		return
+	}
 	err = stmt.fc.wp.opExecute(stmt, args, stmt.inputXsqlda)
 	if err != nil {
 		return
@@ -146,6 +167,10 @@ func (stmt *firebirdsqlStmt) query(ctx context.Context, args []driver.Value) (dr
 
 	if stmt.stmtHandle == -1 {
 		stmt, err = newFirebirdsqlStmt(stmt.fc, stmt.queryString)
+	}
+
+	if err = stmt.ensureInputXsqlda(args); err != nil {
+		return nil, err
 	}
 
 	if stmt.stmtType == isc_info_sql_stmt_exec_procedure {
@@ -225,7 +250,7 @@ func newFirebirdsqlStmt(fc *firebirdsqlConn, query string) (stmt *firebirdsqlStm
 		return
 	}
 
-	stmt.stmtType, stmt.resultXsqlda, stmt.inputXsqlda, err = stmt.fc.wp.parse_xsqlda(buf, stmt.stmtHandle)
+	stmt.stmtType, stmt.resultXsqlda, err = stmt.fc.wp.parse_xsqlda(buf, stmt.stmtHandle)
 	if err != nil {
 		return nil, err
 	}

--- a/utils.go
+++ b/utils.go
@@ -233,12 +233,20 @@ func _dateToBlr(t time.Time) ([]byte, []byte) {
 	return blr, v
 }
 
+func _timeToBlrNoTZ(t time.Time) ([]byte, []byte) {
+	return []byte{13}, _convert_time(t)
+}
+
+func _timestampToBlrNoTZ(t time.Time) ([]byte, []byte) {
+	return []byte{35}, _convert_timestamp(t)
+}
+
 func _timeToBlr(t time.Time, protocolVersion int32, sessionTimezone string) ([]byte, []byte) {
 	if protocolVersion >= PROTOCOL_VERSION16 {
 		tzID := resolveTimezone(t.Location().String(), sessionTimezone)
 		return []byte{28}, _convert_time_tz(t, tzID)
 	}
-	return []byte{13}, _convert_time(t)
+	return _timeToBlrNoTZ(t)
 }
 
 func _timestampToBlr(t time.Time, protocolVersion int32, sessionTimezone string) ([]byte, []byte) {
@@ -246,7 +254,7 @@ func _timestampToBlr(t time.Time, protocolVersion int32, sessionTimezone string)
 		tzID := resolveTimezone(t.Location().String(), sessionTimezone)
 		return []byte{29}, _convert_timestamp_tz(t, tzID)
 	}
-	return []byte{35}, _convert_timestamp(t)
+	return _timestampToBlrNoTZ(t)
 }
 
 func convertToBool(s string, defaultValue bool) bool {

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -654,7 +654,7 @@ func (p *wireProtocol) _parse_select_items(buf []byte, xsqlda []xSQLVAR) (int, e
 	return -1, err // no more info
 }
 
-func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQLVAR, []xSQLVAR, error) {
+func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQLVAR, error) {
 	var ln, col_len, next_index int
 	var err error
 	var stmt_type int32
@@ -675,32 +675,40 @@ func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQL
 			col_len = int(bytes_to_int32(buf[i : i+ln]))
 			xsqlda = make([]xSQLVAR, col_len)
 			next_index, err = p._parse_select_items(buf[i+ln:], xsqlda)
+			if err != nil {
+				return stmt_type, nil, err
+			}
 			for next_index > 0 { // more describe vars
-				p.opInfoSql(stmtHandle,
+				if err = p.opInfoSql(stmtHandle,
 					bytes.Join([][]byte{
-						[]byte{isc_info_sql_sqlda_start, 2},
+						{isc_info_sql_sqlda_start, 2},
 						int16_to_bytes(int16(next_index)),
 						_INFO_SQL_SELECT_DESCRIBE_VARS(),
-					}, nil))
-
+					}, nil)); err != nil {
+					return stmt_type, nil, err
+				}
 				_, _, buf, err = p.opResponse()
-				// buf[:2] == []byte{0x04,0x07}
+				if err != nil {
+					return stmt_type, nil, err
+				}
+				if len(buf) < 4 {
+					return stmt_type, nil, fmt.Errorf("firebirdsql: short select describe continuation (%d bytes)", len(buf))
+				}
 				ln = int(bytes_to_int16(buf[2:4]))
-				// bytes_to_int(buf[4:4+l]) == col_len
+				if ln < 0 || 4+ln >= len(buf) {
+					return stmt_type, nil, fmt.Errorf("firebirdsql: invalid select describe continuation length")
+				}
 				next_index, err = p._parse_select_items(buf[4+ln:], xsqlda)
+				if err != nil {
+					return stmt_type, nil, err
+				}
 			}
 		} else {
 			break
 		}
 	}
 
-	// Fetch input (bind) parameter metadata via a separate opInfoSql call.
-	var inputXsqlda []xSQLVAR
-	if err == nil {
-		inputXsqlda, err = p._fetchBindXsqlda(stmtHandle)
-	}
-
-	return stmt_type, xsqlda, inputXsqlda, err
+	return stmt_type, xsqlda, err
 }
 
 // _fetchBindXsqlda retrieves input (bind) parameter metadata for a prepared statement.
@@ -713,25 +721,55 @@ func (p *wireProtocol) _fetchBindXsqlda(stmtHandle int32) ([]xSQLVAR, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(buf) < 6 || buf[0] != byte(isc_info_sql_bind) || buf[1] != byte(isc_info_sql_describe_vars) {
+	if len(buf) < 8 {
+		p.debugPrint("_fetchBindXsqlda: short response (%d bytes)", len(buf))
+		return nil, nil
+	}
+	if buf[0] != byte(isc_info_sql_bind) || buf[1] != byte(isc_info_sql_describe_vars) {
+		p.debugPrint("_fetchBindXsqlda: unexpected header %02x %02x", buf[0], buf[1])
 		return nil, nil
 	}
 	ln := int(bytes_to_int16(buf[2:4]))
-	col_len := int(bytes_to_int32(buf[4 : 4+ln]))
+	if ln != 4 || 4+ln > len(buf) {
+		p.debugPrint("_fetchBindXsqlda: unexpected ln=%d", ln)
+		return nil, nil
+	}
+	col_len := int(bytes_to_int32(buf[4:8]))
+	if col_len < 0 || col_len > 65535 {
+		p.debugPrint("_fetchBindXsqlda: invalid col_len=%d", col_len)
+		return nil, nil
+	}
 	inputXsqlda := make([]xSQLVAR, col_len)
 	next_index, err := p._parse_select_items(buf[4+ln:], inputXsqlda)
+	if err != nil {
+		return nil, err
+	}
 	for next_index > 0 {
-		p.opInfoSql(stmtHandle,
+		if err = p.opInfoSql(stmtHandle,
 			bytes.Join([][]byte{
-				[]byte{isc_info_sql_sqlda_start, 2},
+				{isc_info_sql_sqlda_start, 2},
 				int16_to_bytes(int16(next_index)),
 				_INFO_SQL_BIND_DESCRIBE_VARS(),
-			}, nil))
+			}, nil)); err != nil {
+			return nil, err
+		}
 		_, _, buf, err = p.opResponse()
+		if err != nil {
+			return nil, err
+		}
+		if len(buf) < 4 {
+			return nil, fmt.Errorf("firebirdsql: short bind describe continuation (%d bytes)", len(buf))
+		}
 		ln = int(bytes_to_int16(buf[2:4]))
+		if ln < 0 || 4+ln >= len(buf) {
+			return nil, fmt.Errorf("firebirdsql: invalid bind describe continuation length")
+		}
 		next_index, err = p._parse_select_items(buf[4+ln:], inputXsqlda)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return inputXsqlda, err
+	return inputXsqlda, nil
 }
 
 func (p *wireProtocol) getBlobSegments(blobId []byte, transHandle int32) ([]byte, error) {
@@ -1469,25 +1507,25 @@ func (p *wireProtocol) paramsToBlr(transHandle int32, params []driver.Value, pro
 		case float64:
 			blr, v = _float64ToBlr(float64(f))
 		case time.Time:
-			if f.Year() == 0 {
-				if i < len(inputXsqlda) && inputXsqlda[i].sqltype == SQL_TYPE_TIME {
-					// TIME (without TZ) column: encode local wall clock to preserve round-trip.
-					blr, v = []byte{13}, _convert_time(f)
-				} else {
+			var bindType int
+			if i < len(inputXsqlda) {
+				bindType = inputXsqlda[i].sqltype
+			}
+			switch bindType {
+			case SQL_TYPE_TIME:
+				blr, v = _timeToBlrNoTZ(f)
+			case SQL_TYPE_DATE:
+				blr, v = _dateToBlr(f)
+			case SQL_TYPE_TIMESTAMP:
+				blr, v = _timestampToBlrNoTZ(f)
+			case SQL_TYPE_TIME_TZ:
+				blr, v = _timeToBlr(f, protocolVersion, p.timezone)
+			case SQL_TYPE_TIMESTAMP_TZ:
+				blr, v = _timestampToBlr(f, protocolVersion, p.timezone)
+			default:
+				// no bind metadata: fall back to Year()==0 heuristic
+				if f.Year() == 0 {
 					blr, v = _timeToBlr(f, protocolVersion, p.timezone)
-				}
-			} else {
-				if i < len(inputXsqlda) {
-					switch inputXsqlda[i].sqltype {
-					case SQL_TYPE_DATE:
-						// DATE column: encode local wall clock date to preserve round-trip.
-						blr, v = _dateToBlr(f)
-					case SQL_TYPE_TIMESTAMP:
-						// TIMESTAMP (without TZ) column: encode local wall clock to preserve round-trip.
-						blr, v = []byte{35}, _convert_timestamp(f)
-					default:
-						blr, v = _timestampToBlr(f, protocolVersion, p.timezone)
-					}
 				} else {
 					blr, v = _timestampToBlr(f, protocolVersion, p.timezone)
 				}


### PR DESCRIPTION
this mr is continuation of the #245.

it fixes wall-clock round-trip for DATE/TIME/TIMESTAMP when time.Local != UTC 
and adds bounds-checked xsqlda parsing.

## CHANGES
- **wireprotocol.go**:                                          
  - parse_xsqlda no longer fetches bind metadata at prepare time;
  - paramsToBlr time.Time branch rewritten as a switch on server-reported sqltype so DATE/TIME/TIMESTAMP encode wall-clock values correctly regardless of time.Local;
  - bounds-checked continuation loops in parse_xsqlda and _fetchBindXsqlda;
- **statement.go**:
  - ensureInputXsqlda helper deduplicates the lazy bind-fetch in exec/query and fixes silent re-fetching when the server returns no metadata;
- **utils.go**:
  - _timeToBlrNoTZ/_timestampToBlrNoTZ helpers added; _timeToBlr/_timestampToBlr delegate their pre-v16 branch to them;
- **driver_test.go**:                                                                                                                                                                                           
  - TestInsertTimestamp compares wall-clock components instead of UTC instants;
  -  new TestInsertTimeDateLocalWallClock covers DATE/TIME/TIMESTAMP round-trip.
