### PR TITLE
fix: return error from GetString instead of swallowing it

### DIFF
--- a/service_manager.go
+++ b/service_manager.go
@@ -392,7 +392,7 @@ func (svc *ServiceManager) WaitString() (string, error) {
 func (svc *ServiceManager) GetString() (result string, end bool, err error) {
 	var buf []byte
 	if buf, err = svc.GetServiceInfo(GetServiceInfoSPBPreamble(), []byte{isc_info_svc_line}, -1); err != nil {
-		return "", false, nil
+		return "", false, err
 	}
 	if bytes.Compare(buf[:4], []byte{isc_info_svc_line, 0, 0, isc_info_end}) == 0 {
 		return "", true, nil


### PR DESCRIPTION
## Summary

- `GetString()` discards the error from `GetServiceInfo` and returns `("", false, nil)` → this makes `WaitStrings` loop forever on a broken TCP connection since callers never see `end=true` or `err!=nil`
- Fix: return the actual error instead of `nil`

## Context

When using verbose mode (`isc_spb_verbose`) for backup/restore via `BackupManager`, the driver calls `WaitStrings` → `GetString` in a loop. If the Firebird TCP connection breaks (e.g., connection reset by peer), `GetServiceInfo` returns an error, but `GetString` swallows it: `WaitStrings` sees `(end=false, err=nil)` and keeps looping, sending empty strings to the channel indefinitely. The non-verbose path (`Wait` → `IsRunning`) handles this correctly because it propagates errors from `GetServiceInfoInt`.
