### PR TITLE
fix: handle SELECT WITH LOCK (select_for_upd) as a cursored statement in rows, closeCursor, and exec rowcount

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -46,7 +46,8 @@ func newFirebirdsqlRows(ctx context.Context, stmt *firebirdsqlStmt, result []dri
 	rows.ctx = ctx
 	rows.stmt = stmt
 	rows.result = result
-	if stmt.stmtType == isc_info_sql_stmt_select {
+	if stmt.stmtType == isc_info_sql_stmt_select ||
+		stmt.stmtType == isc_info_sql_stmt_select_for_upd {
 		rows.moreData = true
 	}
 	return rows

--- a/statement.go
+++ b/statement.go
@@ -63,7 +63,9 @@ func (stmt *firebirdsqlStmt) Close() error {
 }
 
 func (stmt *firebirdsqlStmt) closeCursor() error {
-	if stmt.stmtHandle == -1 || stmt.stmtType != isc_info_sql_stmt_select {
+	if stmt.stmtHandle == -1 ||
+		(stmt.stmtType != isc_info_sql_stmt_select &&
+			stmt.stmtType != isc_info_sql_stmt_select_for_upd) {
 		return nil
 	}
 	return stmt.freeStatement(DSQL_close)
@@ -133,7 +135,8 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 
 	var rowcount int64
 	if len(buf) >= 32 {
-		if stmt.stmtType == isc_info_sql_stmt_select {
+		if stmt.stmtType == isc_info_sql_stmt_select ||
+			stmt.stmtType == isc_info_sql_stmt_select_for_upd {
 			rowcount = int64(bytes_to_int32(buf[20:24]))
 		} else {
 			rowcount = int64(bytes_to_int32(buf[27:31]) + bytes_to_int32(buf[6:10]) + bytes_to_int32(buf[13:17]))


### PR DESCRIPTION
this mr fixes a bug where certain queries would silently return no results instead of the actual data.

it addresses #133 