### PR TITLE
fix: commit per Stmt.Exec in autocommit mode to fix cross-connection visibility

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -104,6 +104,11 @@ func (stmt *firebirdsqlStmt) ensureInputXsqlda(args []driver.Value) error {
 }
 
 func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (result driver.Result, err error) {
+	if stmt.fc.tx.needBegin {
+		if err = stmt.fc.tx.begin(); err != nil {
+			return
+		}
+	}
 	if err = stmt.ensureInputXsqlda(args); err != nil {
 		return
 	}
@@ -144,6 +149,11 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 
 	result = &firebirdsqlResult{
 		affectedRows: rowcount,
+	}
+	if stmt.fc.tx.isAutocommit {
+		if cerr := stmt.fc.tx.commitRetainging(); cerr != nil {
+			return result, cerr
+		}
 	}
 	return
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -486,8 +486,8 @@ func TestIssue136(t *testing.T) {
 	defer readDB.Close()
 
 	const (
-		rowCount      = 10
-		writeSpacing  = 300 * time.Millisecond
+		rowCount      = 15
+		writeSpacing  = 400 * time.Millisecond
 		pollInterval  = 100 * time.Millisecond
 		visibilitySLA = 500 * time.Millisecond
 	)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -492,6 +492,14 @@ func TestIssue136(t *testing.T) {
 		visibilitySLA = 500 * time.Millisecond
 	)
 
+	// Warm both pools so the first row isn't charged for cold-start handshake latency.
+	if err = writeDB.Ping(); err != nil {
+		t.Fatalf("writeDB ping: %v", err)
+	}
+	if err = readDB.Ping(); err != nil {
+		t.Fatalf("readDB ping: %v", err)
+	}
+
 	writeDone := make(chan struct{})
 	writeTimes := make([]time.Time, rowCount)
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -457,3 +457,88 @@ func TestIssue89(t *testing.T) {
 	conn2.Close()
 
 }
+
+// TestIssue136 verifies that INSERT/UPDATE/DELETE issued via a user-prepared
+// sql.Stmt in autocommit mode become visible to other attachments immediately,
+// not only when the sql.Stmt is closed. See github.com/nakagami/firebirdsql#136.
+func TestIssue136(t *testing.T) {
+	test_dsn := GetTestDSN("test_issue136_")
+
+	setupConn, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("createdb open: %v", err)
+	}
+	if _, err = setupConn.Exec("CREATE TABLE numbers (i INTEGER NOT NULL PRIMARY KEY)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	setupConn.Close()
+
+	writeDB, err := sql.Open("firebirdsql", test_dsn)
+	if err != nil {
+		t.Fatalf("writeDB open: %v", err)
+	}
+	defer writeDB.Close()
+
+	readDB, err := sql.Open("firebirdsql", test_dsn)
+	if err != nil {
+		t.Fatalf("readDB open: %v", err)
+	}
+	defer readDB.Close()
+
+	const (
+		rowCount      = 10
+		writeSpacing  = 300 * time.Millisecond
+		pollInterval  = 100 * time.Millisecond
+		visibilitySLA = 500 * time.Millisecond
+	)
+
+	writeDone := make(chan struct{})
+	writeTimes := make([]time.Time, rowCount)
+
+	go func() {
+		defer close(writeDone)
+		stmt, perr := writeDB.Prepare("INSERT INTO numbers (i) VALUES (?)")
+		if perr != nil {
+			t.Errorf("prepare failed: %v", perr)
+			return
+		}
+		defer stmt.Close()
+		for i := 0; i < rowCount; i++ {
+			if _, eerr := stmt.Exec(i); eerr != nil {
+				t.Errorf("exec %d failed: %v", i, eerr)
+				return
+			}
+			writeTimes[i] = time.Now()
+			time.Sleep(writeSpacing)
+		}
+	}()
+
+	observedAt := make([]time.Time, rowCount)
+	deadline := time.Now().Add(time.Duration(rowCount)*writeSpacing + visibilitySLA)
+	seen := 0
+	for seen < rowCount && time.Now().Before(deadline) {
+		var max int
+		err := readDB.QueryRow("SELECT COALESCE(MAX(i), -1) FROM numbers").Scan(&max)
+		if err != nil {
+			t.Fatalf("poll query failed: %v", err)
+		}
+		now := time.Now()
+		for seen <= max {
+			observedAt[seen] = now
+			seen++
+		}
+		time.Sleep(pollInterval)
+	}
+
+	<-writeDone
+
+	if seen < rowCount {
+		t.Fatalf("reader saw only %d/%d rows before deadline — writer commits not propagating", seen, rowCount)
+	}
+	for i := 0; i < rowCount; i++ {
+		lag := observedAt[i].Sub(writeTimes[i])
+		if lag > visibilitySLA {
+			t.Fatalf("row %d visible after %v (> %v) — writer autocommit broken", i, lag, visibilitySLA)
+		}
+	}
+}


### PR DESCRIPTION
this mr addresses #136 

## TROUBLE
the Stmt.Exec on a user-prepared statement never commits between calls, it means that all inserts are queued in one transaction until stmt.Close(), so other connections see nothing for the full loop duration. 

## FIX                                                            
add commitRetaining after each successful exec when `isAutocommit = true` in statement.go, matching the existing behavior on the reader/query path.
