### PR TITLE
fix: always use primary connection host for event aux channel, ignoring unreliable server-supplied address

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -4,10 +4,14 @@ package firebirdsql
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
+	"net/netip"
+	"reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"syscall"
 )
 
 type Subscription struct {
@@ -163,15 +167,35 @@ func (s *Subscription) connAuxRequest() (int32, string, error) {
 	if err != nil {
 		return -1, "", err
 	}
-	// The address Firebird returns here is unreliable: it may be 0.0.0.0
-	// (wildcard bind), the server's private IP (NAT), or garbage on FB3+
-	// where the field is documented as untrustworthy. Reuse the host from
-	// the primary connection — it is reachable by definition. Matches
-	// fbclient (aux_connect in inet.cpp) and jaybird.
+	family := bytes_to_int16(buf[0:2])
 	port := binary.BigEndian.Uint16(buf[2:4])
-	host, _, err := net.SplitHostPort(s.fc.dsn.addr)
-	if err != nil {
-		return -1, "", err
+
+	var addr netip.Addr
+	switch family {
+	case syscall.AF_INET:
+		addr = netip.AddrFrom4([4]byte(buf[4:8]))
+	case syscall.AF_INET6:
+		if reflect.DeepEqual(buf[4:20], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}) {
+			addr = netip.AddrFrom4([4]byte(buf[20:24]))
+		} else {
+			addr = netip.AddrFrom16([16]byte(buf[4:20]))
+		}
+	default:
+		return -1, "", fmt.Errorf("unsupported  family protocol: %x", family)
+	}
+
+	var host string
+	if addr.IsUnspecified() {
+		// Server is bound to all interfaces (RemoteBindAddress empty), so it
+		// reports 0.0.0.0 / :: which the client cannot route to. Fall back to
+		// the host the primary connection used — it is reachable by definition.
+		// See: https://github.com/nakagami/firebirdsql/issues/156
+		host, _, err = net.SplitHostPort(s.fc.dsn.addr)
+		if err != nil {
+			return -1, "", err
+		}
+	} else {
+		host = addr.String()
 	}
 	return auxHandle, net.JoinHostPort(host, strconv.Itoa(int(port))), nil
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -4,12 +4,10 @@ package firebirdsql
 
 import (
 	"encoding/binary"
-	"fmt"
-	"net/netip"
-	"reflect"
+	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
-	"syscall"
 )
 
 type Subscription struct {
@@ -100,11 +98,11 @@ func (s *Subscription) queueEvents(eventID int32) error {
 }
 
 func (s *Subscription) getEventManager() (*eventManager, error) {
-	auxHandle, addrPort, err := s.connAuxRequest()
+	auxHandle, address, err := s.connAuxRequest()
 	if err != nil {
 		return nil, err
 	}
-	newManager, err := newEventManager(addrPort.String(), auxHandle)
+	newManager, err := newEventManager(address, auxHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -155,35 +153,27 @@ func (s *Subscription) unsubscribeNoNotify() error {
 	return s.Unsubscribe()
 }
 
-func (s *Subscription) connAuxRequest() (int32, *netip.AddrPort, error) {
+func (s *Subscription) connAuxRequest() (int32, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.fc.wp.opConnectRequest(); err != nil {
-		return -1, nil, err
+		return -1, "", err
 	}
 	auxHandle, _, buf, err := s.fc.wp.opResponse()
 	if err != nil {
-		return -1, nil, err
+		return -1, "", err
 	}
-	family := bytes_to_int16(buf[0:2])
+	// The address Firebird returns here is unreliable: it may be 0.0.0.0
+	// (wildcard bind), the server's private IP (NAT), or garbage on FB3+
+	// where the field is documented as untrustworthy. Reuse the host from
+	// the primary connection — it is reachable by definition. Matches
+	// fbclient (aux_connect in inet.cpp) and jaybird.
 	port := binary.BigEndian.Uint16(buf[2:4])
-
-	var addr netip.Addr
-	if family == syscall.AF_INET {
-		addr = netip.AddrFrom4([4]byte(buf[4:8]))
-	} else if family == syscall.AF_INET6 {
-		if reflect.DeepEqual(buf[4:20], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}) {
-			addr = netip.AddrFrom4([4]byte(buf[20:24]))
-		} else {
-			addr = netip.AddrFrom16([16]byte(buf[4:20]))
-		}
-	} else {
-
-		err = fmt.Errorf("unsupported  family protocol: %x", family)
-		return -1, nil, err
+	host, _, err := net.SplitHostPort(s.fc.dsn.addr)
+	if err != nil {
+		return -1, "", err
 	}
-	addrPort := netip.AddrPortFrom(addr, port)
-	return auxHandle, &addrPort, nil
+	return auxHandle, net.JoinHostPort(host, strconv.Itoa(int(port))), nil
 }
 
 func (s *Subscription) NotifyClose(receiver chan error) {


### PR DESCRIPTION
this mr addresses the #156 issue.

## PROBLEM
when a Firebird server is bound to all interfaces (RemoteBindAddress empty), it reports 0.0.0.0 (or ::) as the address for the auxiliary event channel.
that address is not routable from a remote client and the dial is refused and events never arrive.
                                                                                                                                                                                                            
## FiX                                                 
when (and only when) the server-supplied address is unspecified, substitute the host from the primary connection's DSN.
that host is reachable by definition because the primary connection is already running on it.

all other addresses, including real IPs returned by Docker-bridged servers, pass through untouched.

## NOTE
why not the broader fbclient/jaybird approach?

both reference drivers unconditionally ignore the server-supplied address and always use the original host.
that approach regresses the existing FB2.5 CI, which runs Firebird in a Docker container with bridge networking: the server's bridge IP is the only path to the dynamically-allocated aux port, and discarding it breaks event tests. 

so we avoid this. (?)

**_P.S.: see comments below._**
