### PR TITLE
fix: propagate getBlobSegments error in rows.Next to prevent silent corrupt-blob success

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -117,6 +117,9 @@ func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
 			blobId := v.([]byte)
 			var blob []byte
 			blob, err = rows.stmt.fc.wp.getBlobSegments(blobId, rows.stmt.fc.tx.transHandle)
+			if err != nil {
+				return
+			}
 			if rows.stmt.resultXsqlda[i].sqlsubtype == 1 {
 				charset := rows.stmt.fc.wp.charset
 				if s, ok := decodeCharset(blob, charset); ok {


### PR DESCRIPTION
this mr improves the getBlobSegments (issue #191 follow-up): it fixes the remaining error-propagation trouble.

the #191 issue itself was fixed in the #239 mr.