### PR TITLE
fix: return re-prepare error in query() instead of nil-derefing on failed stmtHandle

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -180,6 +180,9 @@ func (stmt *firebirdsqlStmt) query(ctx context.Context, args []driver.Value) (dr
 
 	if stmt.stmtHandle == -1 {
 		stmt, err = newFirebirdsqlStmt(stmt.fc, stmt.queryString)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err = stmt.ensureInputXsqlda(args); err != nil {


### PR DESCRIPTION
this mr fixes following:

it adds the missing `if err != nil` check after newFirebirdsqlStmt inside query(), when `stmtHandle == -1` (set by closeCursor) triggers a re-prepare and that re-prepare fails, the returned nil stmt was used immediately, causing a panic.
