### PR TITLE
fix: add stmtHandle==-1 re-prepare guard to exec, mirror query's needBegin form

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -111,6 +111,12 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 			return
 		}
 	}
+	if stmt.stmtHandle == -1 {
+		stmt, err = newFirebirdsqlStmt(stmt.fc, stmt.queryString)
+		if err != nil {
+			return
+		}
+	}
 	if err = stmt.ensureInputXsqlda(args); err != nil {
 		return
 	}
@@ -172,8 +178,7 @@ func (stmt *firebirdsqlStmt) query(ctx context.Context, args []driver.Value) (dr
 	var done = make(chan struct{}, 1)
 
 	if stmt.fc.tx.needBegin {
-		err := stmt.fc.tx.begin()
-		if err != nil {
+		if err = stmt.fc.tx.begin(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
this mr is a follow-up to #256.

## CHANGES
- added the missing `stmtHandle == -1` re-prepare guard in exec(), mirroring the one already present in query();
- normalized query()'s needBegin block from `err := shadowed local err` to `err = named err return`, making the two preambles byte-equivalent mirrors.

## REASON
the exec() and query() should behave symmetrically.

and we do not extract a helper function, the duplication is intentional to make it more clear and explicit.
