### PR TITLE
feat: add replica mode support to `MaintenanceManager`

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -319,6 +319,11 @@ const (
 	isc_spb_prp_sm_single = 2
 	isc_spb_prp_sm_full   = 3
 
+	// Parameters for isc_spb_prp_replica_mode
+	isc_spb_prp_rm_none      = 0
+	isc_spb_prp_rm_readonly  = 1
+	isc_spb_prp_rm_readwrite = 2
+
 	// Parameters for isc_action_svc_repair
 	isc_spb_rpr_commit_trans         = 15
 	isc_spb_rpr_rollback_trans       = 34
@@ -612,4 +617,12 @@ const (
 	ShutdownModeExDenyNewAttachments ShutdownModeEx = isc_spb_prp_attachments_shutdown
 	//ShutdownModeExDenyNewTransactions Disable new transactions for N seconds then shutdown
 	ShutdownModeExDenyNewTransactions ShutdownModeEx = isc_spb_prp_transactions_shutdown
+)
+
+type ReplicaMode byte
+
+const (
+	ReplicaModeNone      ReplicaMode = isc_spb_prp_rm_none
+	ReplicaModeReadOnly  ReplicaMode = isc_spb_prp_rm_readonly
+	ReplicaModeReadWrite ReplicaMode = isc_spb_prp_rm_readwrite
 )

--- a/maintenance_manager.go
+++ b/maintenance_manager.go
@@ -80,6 +80,13 @@ func (mm *MaintenanceManager) SetWriteModeSync(database string) error {
 	return mm.setWriteMode(database, isc_spb_prp_wm_sync)
 }
 
+func (mm *MaintenanceManager) SetReplicaMode(database string, mode ReplicaMode) error {
+	spb := NewXPBWriterFromTag(isc_action_svc_properties)
+	spb.PutString(isc_spb_dbname, database)
+	spb.PutByte(isc_spb_prp_replica_mode, byte(mode))
+	return mm.attach(spb.Bytes(), nil)
+}
+
 func (mm *MaintenanceManager) setPageFill(database string, mode byte) error {
 	spb := NewXPBWriterFromTag(isc_action_svc_properties)
 	spb.PutString(isc_spb_dbname, database)

--- a/maintenance_manager_test.go
+++ b/maintenance_manager_test.go
@@ -330,6 +330,24 @@ func TestServiceManager_SetSweepInterval(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServiceManager_SetReplicaMode(t *testing.T) {
+	if get_firebird_major_version(t) < 4 {
+		t.Skip("replica mode requires Firebird 4.0 or newer")
+	}
+
+	db, _, err := CreateTestDatabase("test_set_replica_mode_")
+	require.NoError(t, err)
+
+	m, err := NewMaintenanceManager("localhost:3050", GetTestUser(), GetTestPassword(), GetDefaultServiceManagerOptions())
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	for _, mode := range []ReplicaMode{ReplicaModeReadOnly, ReplicaModeReadWrite, ReplicaModeNone} {
+		err = m.SetReplicaMode(db, mode)
+		assert.NoError(t, err)
+	}
+}
+
 func TestServiceManager_NoLinger(t *testing.T) {
 	if get_firebird_major_version(t) < 3 {
 		t.Skip("firebird 2.5 do not support isc_spb_prp_nolinger")


### PR DESCRIPTION
## Summary

- Add `isc_spb_prp_rm_none` (`0`), `isc_spb_prp_rm_readonly` (`1`), `isc_spb_prp_rm_readwrite` (`2`) constants for `isc_spb_prp_replica_mode`
- Add `ReplicaMode` type with `ReplicaModeNone` / `ReplicaModeReadOnly` / `ReplicaModeReadWrite`
- Add `MaintenanceManager.SetReplicaMode(database string, mode ReplicaMode) error`

This corresponds to `gfix -replica {none|read_only|read_write}` in Firebird 4.0+.

The const `isc_spb_prp_replica_mode` (`46`) was already defined in `consts.go` but had no wrapper.

## References

- [Firebird gfix replica mode](https://www.firebirdsql.org/file/documentation/html/en/firebirddocs/gfix/firebird-gfix.html#gfix-replica) — replica option
- [Jaybird ISCConstants.java](https://github.com/FirebirdSQL/jaybird/blob/9887d5a5a8b201d23e83883e203fcb098161daef/src/main/org/firebirdsql/gds/ISCConstants.java#L236-L240) — authoritative constant values