### PR TITLE
fix: avoid starting transactions during Ping

### DIFF
--- a/driver_go18.go
+++ b/driver_go18.go
@@ -29,6 +29,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"sort"
+	"time"
 )
 
 func flattenNamedValues(named []driver.NamedValue) []driver.Value {
@@ -89,14 +90,57 @@ func (fc *firebirdsqlConn) Ping(ctx context.Context) (err error) {
 	if fc == nil {
 		return errors.New("Connection was closed")
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
-	rows, err := fc.query(ctx, "SELECT 1 from rdb$database", nil)
+	stopWatchingContext, err := fc.watchPingContext(ctx)
 	if err != nil {
 		return driver.ErrBadConn
 	}
-	rows.Close()
+	if stopWatchingContext != nil {
+		defer stopWatchingContext()
+	}
+
+	// Use attachment-level database info so Ping does not create a SQL statement or transaction.
+	if err := fc.wp.opInfoDatabase([]byte{isc_info_implementation, isc_info_end}); err != nil {
+		return driver.ErrBadConn
+	}
+	if _, _, _, err := fc.wp.opResponse(); err != nil {
+		return driver.ErrBadConn
+	}
 
 	return nil
+}
+
+func (fc *firebirdsqlConn) watchPingContext(ctx context.Context) (func(), error) {
+	ctxDone := ctx.Done()
+	if ctxDone == nil {
+		return nil, nil
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := fc.wp.conn.conn.SetDeadline(deadline); err != nil {
+			return nil, err
+		}
+	}
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		select {
+		case <-ctxDone:
+			_ = fc.wp.conn.conn.SetDeadline(time.Now())
+		case <-done:
+		}
+	}()
+
+	return func() {
+		close(done)
+		<-finished
+		_ = fc.wp.conn.conn.SetDeadline(time.Time{})
+	}, nil
 }
 
 func (fc *firebirdsqlConn) QueryContext(ctx context.Context, query string, namedargs []driver.NamedValue) (rows driver.Rows, err error) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -25,7 +25,9 @@ package firebirdsql
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 )
@@ -320,6 +322,96 @@ func TestIssue67(t *testing.T) {
 		t.Fatalf("Error Close: %v", err)
 	}
 
+}
+
+func TestPingDoesNotOpenTransaction(t *testing.T) {
+	test_dsn := GetTestDSN("test_ping_no_transaction_")
+	conn1, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn1.Close()
+
+	ctx := context.Background()
+	pingConn, err := conn1.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting dedicated ping connection: %v", err)
+	}
+	defer pingConn.Close()
+
+	if err = pingConn.PingContext(ctx); err != nil {
+		t.Fatalf("Error ping: %v", err)
+	}
+
+	conn2, err := sql.Open("firebirdsql", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting monitor connection: %v", err)
+	}
+	defer conn2.Close()
+
+	var numberTrans int
+	err = conn2.QueryRowContext(ctx, "select count(*) from mon$transactions where mon$attachment_id <> current_connection").Scan(&numberTrans)
+	if err != nil {
+		t.Fatalf("Error querying monitor transactions: %v", err)
+	}
+	if numberTrans != 0 {
+		t.Fatalf("Ping opened %d transaction(s)", numberTrans)
+	}
+}
+
+func TestPingContextCanceled(t *testing.T) {
+	test_dsn := GetTestDSN("test_ping_context_canceled_")
+	conn, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	pingConn, err := conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Error getting dedicated ping connection: %v", err)
+	}
+	defer pingConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = pingConn.PingContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestPingClearsDeadline(t *testing.T) {
+	test_dsn := GetTestDSN("test_ping_clears_deadline_")
+	conn, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	pingConn, err := conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Error getting dedicated ping connection: %v", err)
+	}
+	defer pingConn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if err = pingConn.PingContext(ctx); err != nil {
+		t.Fatalf("Error ping: %v", err)
+	}
+
+	time.Sleep(600 * time.Millisecond)
+
+	var n int
+	err = pingConn.QueryRowContext(context.Background(), "select 1 from rdb$database").Scan(&n)
+	if err != nil {
+		t.Fatalf("Error querying after ping: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1, got %d", n)
+	}
 }
 
 func TestIssue89(t *testing.T) {


### PR DESCRIPTION
## What changed

This changes `Conn.Ping` to use Firebird attachment-level database info (`op_info_database`) instead of executing `SELECT 1 from rdb$database`.

The ping now performs a real round trip to the server without allocating a SQL statement, starting a transaction, fetching rows, or relying on autocommit cleanup. If the database info round trip fails, the connection is considered unsafe for reuse and `Ping` returns `driver.ErrBadConn` so `database/sql` can discard it from the pool.

Context cancellation/deadlines are handled by applying a temporary network deadline while the ping round trip is in progress, then clearing it before returning.

## Why

The previous SQL-based ping went through normal statement execution. On Firebird that path starts a transaction and, in autocommit mode, statement cleanup uses `COMMIT RETAINING`.

For application code and connection pools that call `db.Ping`, GORM automatic ping, health checks, reconnect logic, or pool validation often, this can leave retained transaction contexts on otherwise idle attachments. Long-lived retained transactions can hold back OAT and interfere with garbage collection/sweep behavior.

`Ping` should only verify that the attachment is alive and the server responds. Firebird already has an attachment-level database information request for that purpose, so using it avoids changing the SQL/transaction state of the connection.

## Tests

- `TMPDIR=/tmp go test -run 'TestPingDoesNotOpenTransaction|TestPingContextCanceled|TestPingClearsDeadline|TestIssue89|TestAuth|TestGoIssue44' ./...`
- `go test -run '^$' ./...`

I added tests covering that `Ping` does not leave a transaction visible in `mon$transactions`, canceled contexts are respected, and a regular query still works after a successful ping with a deadline.
