### PR TITLE
fix: Commit Ping transaction after SQL check

### DIFF
--- a/driver_go18.go
+++ b/driver_go18.go
@@ -28,6 +28,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"sort"
 )
 
@@ -87,14 +88,40 @@ func (fc *firebirdsqlConn) ExecContext(ctx context.Context, query string, nameda
 // This file implements the optional pinger interface for the database/sql package
 func (fc *firebirdsqlConn) Ping(ctx context.Context) (err error) {
 	if fc == nil {
-		return errors.New("Connection was closed")
+		return fmt.Errorf("connection was closed: %w", driver.ErrBadConn)
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Keep Ping as a SQL check, but do not leave the connection's autocommit
+	// transaction context open through COMMIT RETAINING.
+	previousTx := fc.tx
+	pingTx, err := newFirebirdsqlTx(fc, ISOLATION_LEVEL_READ_COMMITED_RO, false, true)
+	if err != nil {
+		return fmt.Errorf("ping begin transaction failed: %w: %w", err, driver.ErrBadConn)
+	}
+	fc.tx = pingTx
+	committed := false
+	defer func() {
+		fc.tx = previousTx
+		if !committed {
+			_ = pingTx.Rollback()
+		}
+		delete(fc.transactionSet, pingTx)
+	}()
 
 	rows, err := fc.query(ctx, "SELECT 1 from rdb$database", nil)
 	if err != nil {
-		return driver.ErrBadConn
+		return fmt.Errorf("ping query failed: %w: %w", err, driver.ErrBadConn)
 	}
-	rows.Close()
+	if err = rows.Close(); err != nil {
+		return fmt.Errorf("ping rows close failed: %w: %w", err, driver.ErrBadConn)
+	}
+	if err = pingTx.Commit(); err != nil {
+		return fmt.Errorf("ping commit failed: %w: %w", err, driver.ErrBadConn)
+	}
+	committed = true
 
 	return nil
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -25,7 +25,9 @@ package firebirdsql
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 )
@@ -320,6 +322,73 @@ func TestIssue67(t *testing.T) {
 		t.Fatalf("Error Close: %v", err)
 	}
 
+}
+
+func TestPingCommitsTransaction(t *testing.T) {
+	test_dsn := GetTestDSN("test_ping_commits_transaction_")
+	conn1, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn1.Close()
+
+	ctx := context.Background()
+	pingConn, err := conn1.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting dedicated ping connection: %v", err)
+	}
+	defer pingConn.Close()
+
+	if err = pingConn.PingContext(ctx); err != nil {
+		t.Fatalf("Error ping: %v", err)
+	}
+
+	conn2, err := sql.Open("firebirdsql", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting monitor connection: %v", err)
+	}
+	defer conn2.Close()
+
+	var numberTrans int
+	err = conn2.QueryRowContext(ctx, "select count(*) from mon$transactions where mon$attachment_id <> current_connection").Scan(&numberTrans)
+	if err != nil {
+		t.Fatalf("Error querying monitor transactions: %v", err)
+	}
+	if numberTrans != 0 {
+		t.Fatalf("Ping left %d transaction(s)", numberTrans)
+	}
+
+	var n int
+	err = pingConn.QueryRowContext(ctx, "select 1 from rdb$database").Scan(&n)
+	if err != nil {
+		t.Fatalf("Error querying after ping: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1, got %d", n)
+	}
+}
+
+func TestPingContextCanceled(t *testing.T) {
+	test_dsn := GetTestDSN("test_ping_context_canceled_")
+	conn, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	pingConn, err := conn.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Error getting dedicated ping connection: %v", err)
+	}
+	defer pingConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = pingConn.PingContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
 }
 
 func TestIssue89(t *testing.T) {


### PR DESCRIPTION
## What changed

This keeps `Conn.Ping` as a SQL execution check using `SELECT 1 from rdb$database`, but runs that check in a dedicated read-only transaction and finishes it with a regular `COMMIT`.

The previous connection transaction context is restored after the ping, so the pooled connection can continue using its normal autocommit state.

The ping path now also:

- returns an error wrapping `driver.ErrBadConn` when the connection is closed or the ping connection becomes unsafe for reuse
- preserves the underlying error as a wrapped error for begin/query/rows-close/commit failures
- checks `ctx.Err()` before starting the ping transaction
- rolls back the ping transaction from a single cleanup path if the ping does not commit successfully

## Why

The current ping path executes SQL on the connection's autocommit transaction. Closing the statement then goes through `COMMIT RETAINING`, which keeps the transaction context open on the attachment.

In applications where `database/sql` or higher-level libraries call `Ping()` automatically, repeated SQL-based pings can leave retained transaction contexts on idle pooled connections. Long-lived retained transactions can hold back OAT and interfere with garbage collection/sweep behavior.

This change preserves the value of `Ping()` as a SQL execution check and keeps Firebird 2.5 compatibility, while ensuring the ping transaction is fully finished.

## Tests

- `TMPDIR=/tmp go test -run 'TestPingCommitsTransaction|TestPingContextCanceled|TestIssue89|TestAuth|TestGoIssue44' ./...`
- `TMPDIR=/tmp go test -run '^TestIssue136$' -count=10 ./...`
- `go test -run '^$' ./...`

I added `TestPingCommitsTransaction`, which keeps the ping attachment alive through a dedicated `sql.Conn`, verifies no transaction remains visible for that attachment in `mon$transactions`, and confirms the same connection can still execute SQL after `Ping()`.

I also added `TestPingContextCanceled` to verify a canceled context is returned before starting the ping transaction.
