### PR TITLE
fix: honor sqlscale for SQL_TYPE_INT128 on read (NUMERIC/DECIMAL p>=19)

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -793,6 +793,68 @@ func TestNegativeInt128(t *testing.T) {
 	conn.Close()
 }
 
+// TestNumericInt128Scaled verifies that NUMERIC(p, s) and DECIMAL(p, s) with
+// p in 19-38 (stored as SQL_TYPE_INT128) honor sqlscale on read. Pre-fix the
+// driver returned the raw unscaled integer string ("12345000" for 123.45);
+// post-fix it routes through formatDecimalGDA matching scaledIntValue and
+// preserves the IEEE 754 cohort quantum that #268 established.
+func TestNumericInt128Scaled(t *testing.T) {
+	conn, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_numeric_int128_scaled_"))
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer conn.Close()
+
+	if get_firebird_major_version(t) < 4 {
+		return
+	}
+
+	ddl := `
+        CREATE TABLE test_numeric_int128_scaled (
+            a NUMERIC(38, 0),
+            b NUMERIC(38, 5),
+            c NUMERIC(38, 18),
+            d NUMERIC(38, 38),
+            neg NUMERIC(38, 5)
+        )
+    `
+	if _, err := conn.Exec(ddl); err != nil {
+		t.Fatalf("CREATE TABLE failed: %v", err)
+	}
+
+	insert := `
+        INSERT INTO test_numeric_int128_scaled (a, b, c, d, neg) VALUES (
+            99999999999999999999999999999999999999,
+            123.45,
+            1.234567890123456789,
+            0.12345678901234567890123456789012345678,
+            -987.65
+        )
+    `
+	if _, err := conn.Exec(insert); err != nil {
+		t.Fatalf("INSERT failed: %v", err)
+	}
+
+	var a, b, c, d, neg string
+	err = conn.QueryRow("SELECT a, b, c, d, neg FROM test_numeric_int128_scaled").Scan(&a, &b, &c, &d, &neg)
+	if err != nil {
+		t.Fatalf("Error SELECT: %v", err)
+	}
+
+	cases := []struct{ name, got, want string }{
+		{"NUMERIC(38, 0) max positive", a, "99999999999999999999999999999999999999"},
+		{"NUMERIC(38, 5) trailing zeros preserved", b, "123.45000"},
+		{"NUMERIC(38, 18) full precision", c, "1.234567890123456789"},
+		{"NUMERIC(38, 38) sub-unit", d, "0.12345678901234567890123456789012345678"},
+		{"NUMERIC(38, 5) negative", neg, "-987.65000"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
 func TestLegacyAuthWireCrypt(t *testing.T) {
 	test_dsn := GetTestDSN("test_legacy_auth_")
 	var n int

--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -357,7 +357,15 @@ func (x *xSQLVAR) value(raw_value []byte, timezone string, charset string) (v in
 		if raw_value[0]&0x80 != 0 {
 			n.Sub(n, new(big.Int).Lsh(big.NewInt(1), 128))
 		}
-		v = n.String()
+		switch {
+		case x.sqlscale < 0:
+			v = formatDecimalGDA(new(big.Int).Abs(n), int32(x.sqlscale), n.Sign() < 0, "")
+		case x.sqlscale > 0:
+			mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(x.sqlscale)), nil)
+			v = new(big.Int).Mul(n, mul).String()
+		default:
+			v = n.String()
+		}
 	case SQL_TYPE_DATE:
 		v = x.parseDate(raw_value, timezone)
 	case SQL_TYPE_TIME:

--- a/xsqlvar_test.go
+++ b/xsqlvar_test.go
@@ -3,6 +3,7 @@ package firebirdsql
 import (
 	"bytes"
 	"database/sql/driver"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -171,6 +172,78 @@ func TestValueInt128(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			x := &xSQLVAR{sqltype: SQL_TYPE_INT128}
 			got, err := x.value(tt.rawValue, "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// int128Bytes encodes n as a 16-byte big-endian two's-complement value, the
+// on-wire representation Firebird sends for SQL_TYPE_INT128.
+func int128Bytes(n *big.Int) []byte {
+	out := make([]byte, 16)
+	if n.Sign() >= 0 {
+		b := n.Bytes()
+		copy(out[16-len(b):], b)
+		return out
+	}
+	bias := new(big.Int).Lsh(big.NewInt(1), 128)
+	b := new(big.Int).Add(n, bias).Bytes()
+	copy(out[16-len(b):], b)
+	return out
+}
+
+func TestValueInt128WithScale(t *testing.T) {
+	maxPos := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+	minNeg := new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 127))
+
+	tests := []struct {
+		name     string
+		value    *big.Int
+		sqlscale int
+		want     string
+	}{
+		// Zero scale — current behavior must be preserved (TestInt128/TestNegativeInt128 path).
+		{"scale 0, +1", big.NewInt(1), 0, "1"},
+		{"scale 0, -1", big.NewInt(-1), 0, "-1"},
+
+		// Negative scale, formatPlain branch (exponent <= 0 && adjexp >= -6).
+		// Trailing zeros are preserved per IEEE 754 cohort quantum, matching #268.
+		{"scale -5, +12345000 → 123.45000", big.NewInt(12345000), -5, "123.45000"},
+		{"scale -5, -12345000 → -123.45000", big.NewInt(-12345000), -5, "-123.45000"},
+		{"scale -2, +99 → 0.99", big.NewInt(99), -2, "0.99"},
+		{"scale -2, -99 → -0.99", big.NewInt(-99), -2, "-0.99"},
+
+		// Zero coefficient at negative scale — IEEE 754 cohort quantum:
+		// "0.00000" preserves the column's scale information, matching
+		// Jaybird / Python firebird-driver / decNumber.
+		{"scale -5, 0 (cohort quantum)", big.NewInt(0), -5, "0.00000"},
+
+		// Positive scale — multiply by 10^scale via big.Int (overflow-safe).
+		{"scale +2, +5 → 500", big.NewInt(5), 2, "500"},
+		{"scale +2, -5 → -500", big.NewInt(-5), 2, "-500"},
+
+		// Large positive scale on near-max INT128 — proves big.Int.Exp +
+		// big.Int.Mul renders a 49-digit string without overflow,
+		// scientific fallback, or precision loss (the failure modes #18
+		// documents for the SHORT/LONG/INT64 helper).
+		{"scale +10, 2^127-1 (49-digit string)", maxPos, 10, "1701411834604692317316873037158841057270000000000"},
+
+		// Boundary: 2^127 - 1 with scale -38, the canonical NUMERIC(38, 38) max.
+		// digits len = 39, exponent = -38, adjexp = 0 → formatPlain → "1." + 38 frac digits.
+		{"scale -38, 2^127-1", maxPos, -38, "1.70141183460469231731687303715884105727"},
+		// Boundary: -2^127 with scale -38 (NUMERIC(38, 38) min).
+		{"scale -38, -2^127", minNeg, -38, "-1.70141183460469231731687303715884105728"},
+
+		// formatPlain → formatScientific crossover: adjexp < -6 forces scientific.
+		// digits len = 5, exponent = -20, adjexp = -16 → formatScientific → "1.2345E-16".
+		{"scale -20, +12345 (scientific)", big.NewInt(12345), -20, "1.2345E-16"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := &xSQLVAR{sqltype: SQL_TYPE_INT128, sqlscale: tt.sqlscale}
+			got, err := x.value(int128Bytes(tt.value), "", "")
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
this mr is a continuation of #268.

this mr makes SQL_TYPE_INT128 honor sqlscale on read.

## PROBLEM
NUMERIC(p,s) and DECIMAL(p,s) with p in 19–38 are stored as INT128, with scale carried out-of-band.
the old code dropped it: NUMERIC(38,5) storing 123.45 came back as "12345000".
now it returns "123.45000", matching Jaybird and Python firebird-driver.

## CHANGES
a three-branch switch in xsqlvar.go:
- negative scale routes through formatDecimalGDA (matching the existing SHORT/LONG/INT64 helper);
- positive scale uses big.Int.Exp/Mul (overflow-safe);
- zero scale stays as the prior n.String().

plus unit + integration tests.
