### PR TITLE
fix: add auth_plugin_list allow-list to block Legacy_Auth downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ param1, param2... are
 
 | Name | Description | Default | Note |
 | --- | --- | --- | --- |
-| auth_plugin_name | Authentication plugin name. | Srp256 | Srp256/Srp/Legacy_Auth are available. |
+| auth_plugin_name | Preferred authentication plugin. Must be a member of `auth_plugin_list`. | Srp256 | Srp256/Srp/Legacy_Auth are available. |
+| auth_plugin_list | Ordered, comma-separated allow-list of acceptable authentication plugins (a subset of the supported `Srp256,Srp,Legacy_Auth`). The plugin the server selects must be a member, otherwise the connection is refused before any credentials are sent. Omit a plugin to refuse it (e.g. `Srp256,Srp` to refuse a server-forced downgrade to `Legacy_Auth`, which would otherwise put a brute-forceable DES `crypt(password)` hash on the wire). | Srp256,Srp,Legacy_Auth | `Legacy_Auth` is kept in the default for backward compatibility but is weak; set `Srp256,Srp` to harden. |
 | column_name_to_lower | Force column name to lower | false | For "github.com/jmoiron/sqlx" |
 | role | Role name | | |
 | timezone | IANA time zone name (e.g. `UTC`, `Europe/Berlin`) | | Controls client-side decoding of naive DATE/TIME/TIMESTAMP and server session time zone (FB 4+). See "Time and timestamp handling" below. |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ param1, param2... are
 | column_name_to_lower | Force column name to lower | false | For "github.com/jmoiron/sqlx" |
 | role | Role name | | |
 | timezone | IANA time zone name (e.g. `UTC`, `Europe/Berlin`) | | Controls client-side decoding of naive DATE/TIME/TIMESTAMP and server session time zone (FB 4+). See "Time and timestamp handling" below. |
-| wire_crypt | Enable wire data encryption or not. | true | For Firebird 3.0+ |
+| wire_crypt | Wire-encryption policy, mirroring the server's `WireCrypt` setting. Tri-state `disabled`/`enabled`/`required`, with boolean aliases `false`=`disabled` and `true`=`enabled`. `enabled` encrypts when the server offers a cipher but tolerates plaintext; `required` fails the connection closed on every non-encrypting handshake outcome (including a legacy plain `op_accept` for protocol versions ≤ 12 and an `op_accept_data` with no negotiated cipher), refusing before any credentials are sent. | true (=`enabled`) | For Firebird 3.0+. Against pre-3.0 / non-encrypting servers, `required` is refused (use `enabled` to allow plaintext). |
+| wire_crypt_plugin | Ordered, comma-separated allow-list of acceptable wire ciphers, mirroring the server's `WireCryptPlugin`. Order is client preference; omit a cipher to refuse it (e.g. `ChaCha64,ChaCha` to refuse the deprecated RC4/`Arc4`). | ChaCha64,ChaCha,Arc4 | For Firebird 3.0+. `Arc4` (RC4) is kept for FB 3.0 compatibility but is cryptographically weak. |
 | wire_compress | Enable wire protocol compression. | false | For Firebird 3.0+ (protocol version 13+) |
 | charset | Firebird Charecter Set | | |
 

--- a/auth_plugin.go
+++ b/auth_plugin.go
@@ -1,0 +1,68 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"fmt"
+	"slices"
+)
+
+// defaultAuthPlugins is the set of authentication plugins this driver implements,
+// strongest first. It is the default value of the auth_plugin_list DSN parameter
+// and the supported-set reference that any configured auth_plugin_list is
+// validated against (see validateAuthPlugins). Mirrors defaultWireCryptPlugins.
+const defaultAuthPlugins = "Srp256,Srp,Legacy_Auth"
+
+// isAuthPluginAllowed reports whether plugin is a member of the client allow-list
+// authPluginList (an auth_plugin_list DSN value). It is the core defense against
+// an auth downgrade: a server-selected plugin the client never sanctioned (e.g. a
+// server forcing Legacy_Auth on an Srp256 client) is rejected before any auth
+// blob is computed.
+func isAuthPluginAllowed(plugin, authPluginList string) bool {
+	return slices.Contains(splitList(authPluginList), plugin)
+}
+
+// validateAuthPlugins checks a connection's auth-plugin configuration before the
+// handshake (fail fast). Every entry of authPluginList must be a plugin the
+// driver actually implements (defaultAuthPlugins), and the preferred
+// authPluginName must itself be a member of authPluginList. An empty list is
+// rejected — unlike wire_crypt_plugin, where an empty list legitimately means
+// "refuse all ciphers", an empty auth list leaves no way to authenticate.
+// Mirrors the fail-fast style of parseWireCryptMode.
+func validateAuthPlugins(authPluginName, authPluginList string) error {
+	supported := splitList(defaultAuthPlugins)
+	list := splitList(authPluginList)
+	if len(list) == 0 {
+		return fmt.Errorf("firebirdsql: auth_plugin_list is empty; want a comma-separated subset of %q", defaultAuthPlugins)
+	}
+	for _, p := range list {
+		if !slices.Contains(supported, p) {
+			return fmt.Errorf("firebirdsql: unsupported auth plugin %q in auth_plugin_list (supported: %q)", p, defaultAuthPlugins)
+		}
+	}
+	if !slices.Contains(list, authPluginName) {
+		return fmt.Errorf("firebirdsql: auth_plugin_name %q is not in auth_plugin_list %q", authPluginName, authPluginList)
+	}
+	return nil
+}

--- a/auth_plugin_test.go
+++ b/auth_plugin_test.go
@@ -1,0 +1,123 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIsAuthPluginAllowed(t *testing.T) {
+	cases := []struct {
+		plugin string
+		list   string
+		want   bool
+	}{
+		{"Legacy_Auth", "Srp256,Srp", false}, // the downgrade we must refuse
+		{"Srp", "Srp256,Srp", true},
+		{"Srp256", "Srp256,Srp,Legacy_Auth", true},
+		{"Legacy_Auth", "Srp256,Srp,Legacy_Auth", true}, // explicit opt-in
+		{"Srp256", "", false},
+		{"", "Srp256,Srp", false},
+	}
+	for _, c := range cases {
+		if got := isAuthPluginAllowed(c.plugin, c.list); got != c.want {
+			t.Errorf("isAuthPluginAllowed(%q,%q)=%v, want %v", c.plugin, c.list, got, c.want)
+		}
+	}
+}
+
+func TestValidateAuthPlugins(t *testing.T) {
+	cases := []struct {
+		name    string
+		list    string
+		wantErr bool
+	}{
+		{"Srp256", "Srp256,Srp,Legacy_Auth", false},
+		{"Srp256", "Srp256,Srp", false},
+		{"Legacy_Auth", "Srp256,Srp,Legacy_Auth", false},
+		{"Srp256", "Srp256,FooBar", true},   // unsupported plugin in list
+		{"Legacy_Auth", "Srp256,Srp", true}, // preferred not in list
+		{"Srp256", "", true},                // empty list
+	}
+	for _, c := range cases {
+		err := validateAuthPlugins(c.name, c.list)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateAuthPlugins(%q,%q) err=%v, wantErr=%v", c.name, c.list, err, c.wantErr)
+		}
+	}
+}
+
+// TestUidAdvertisesAuthPluginList verifies that uid() advertises the configured
+// allow-list verbatim and, in particular, does not leak Legacy_Auth onto the wire
+// when it has been excluded from auth_plugin_list.
+func TestUidAdvertisesAuthPluginList(t *testing.T) {
+	clientPublic, _, err := getClientSeed()
+	if err != nil {
+		t.Fatalf("getClientSeed: %v", err)
+	}
+	p := &wireProtocol{}
+
+	hardened := p.uid("sysdba", "masterkey", "Srp256", "Srp256,Srp", true, clientPublic)
+	if !bytes.Contains(hardened, []byte("Srp256,Srp")) {
+		t.Errorf("uid() did not advertise the configured auth_plugin_list")
+	}
+	if bytes.Contains(hardened, []byte("Legacy_Auth")) {
+		t.Errorf("uid() advertised Legacy_Auth though it was excluded from auth_plugin_list")
+	}
+
+	full := p.uid("sysdba", "masterkey", "Srp256", defaultAuthPlugins, true, clientPublic)
+	if !bytes.Contains(full, []byte("Legacy_Auth")) {
+		t.Errorf("uid() did not advertise Legacy_Auth though it was in auth_plugin_list")
+	}
+}
+
+// TestDSNAuthPluginList covers the auth_plugin_list default, an override, and the
+// fail-fast validation wired into parseDSN.
+func TestDSNAuthPluginList(t *testing.T) {
+	dsn, err := parseDSN("user:password@localhost:3050/dbname")
+	if err != nil {
+		t.Fatalf("parseDSN default: %v", err)
+	}
+	if dsn.options["auth_plugin_list"] != defaultAuthPlugins {
+		t.Errorf("default auth_plugin_list=%q, want %q", dsn.options["auth_plugin_list"], defaultAuthPlugins)
+	}
+
+	dsn, err = parseDSN("user:password@localhost:3050/dbname?auth_plugin_list=Srp256,Srp")
+	if err != nil {
+		t.Fatalf("parseDSN override: %v", err)
+	}
+	if dsn.options["auth_plugin_list"] != "Srp256,Srp" {
+		t.Errorf("override auth_plugin_list=%q, want %q", dsn.options["auth_plugin_list"], "Srp256,Srp")
+	}
+
+	// Unsupported plugin in the list must fail fast.
+	if _, err = parseDSN("user:password@localhost:3050/dbname?auth_plugin_list=Srp256,Bogus"); err == nil {
+		t.Errorf("parseDSN accepted an unsupported auth plugin; want error")
+	}
+	// Preferred plugin not in the list must fail fast.
+	if _, err = parseDSN("user:password@localhost:3050/dbname?auth_plugin_name=Legacy_Auth&auth_plugin_list=Srp256,Srp"); err == nil {
+		t.Errorf("parseDSN accepted a preferred plugin not in auth_plugin_list; want error")
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -40,6 +40,20 @@ type firebirdsqlConn struct {
 	transactionSet    map[*firebirdsqlTx]struct{}
 }
 
+// WireCipher returns the name of the wire-encryption cipher negotiated for this
+// connection ("ChaCha64", "ChaCha", or "Arc4"), or an empty string when the
+// connection is unencrypted (plaintext). Because the concrete connection type
+// is unexported, applications reach it through the database/sql layer by
+// asserting sql.Conn.Raw to an interface:
+//
+//	conn.Raw(func(dc any) error {
+//	    cipher := dc.(interface{ WireCipher() string }).WireCipher()
+//	    ...
+//	})
+func (fc *firebirdsqlConn) WireCipher() string {
+	return fc.wp.conn.plugin
+}
+
 // ============ driver.Conn implementation
 
 func (fc *firebirdsqlConn) begin(isolationLevel int) (driver.Tx, error) {

--- a/doc.go
+++ b/doc.go
@@ -56,8 +56,21 @@ Windows database path:
 	db, err := sql.Open("firebirdsql", "sysdba:masterkey@localhost/C:/fbdata/mydb.fdb")
 
 See the README for the full list of optional query parameters (auth_plugin_name,
-charset, role, timezone, wire_crypt, wire_crypt_plugin, wire_compress,
-column_name_to_lower).
+auth_plugin_list, charset, role, timezone, wire_crypt, wire_crypt_plugin,
+wire_compress, column_name_to_lower).
+
+Authentication is controlled by two parameters:
+
+	auth_plugin_name  preferred authentication plugin (default "Srp256"). Must be
+	                  a member of auth_plugin_list.
+	auth_plugin_list  ordered, comma-separated allow-list of acceptable auth
+	                  plugins (default "Srp256,Srp,Legacy_Auth"; must be a subset
+	                  of the supported plugins). The plugin the server selects must
+	                  be a member, otherwise the connection is refused before any
+	                  credentials are sent. Omit a plugin to refuse it — e.g.
+	                  "Srp256,Srp" rejects a server downgrade to Legacy_Auth, which
+	                  would otherwise put a brute-forceable DES crypt(password) hash
+	                  on the wire.
 
 Wire encryption is controlled by two parameters that mirror the Firebird server's
 own WireCrypt / WireCryptPlugin settings:

--- a/doc.go
+++ b/doc.go
@@ -56,6 +56,26 @@ Windows database path:
 	db, err := sql.Open("firebirdsql", "sysdba:masterkey@localhost/C:/fbdata/mydb.fdb")
 
 See the README for the full list of optional query parameters (auth_plugin_name,
-charset, role, timezone, wire_crypt, wire_compress, column_name_to_lower).
+charset, role, timezone, wire_crypt, wire_crypt_plugin, wire_compress,
+column_name_to_lower).
+
+Wire encryption is controlled by two parameters that mirror the Firebird server's
+own WireCrypt / WireCryptPlugin settings:
+
+	wire_crypt        disabled | enabled | required  (default enabled; false/true
+	                  are accepted as aliases for disabled/enabled). "enabled"
+	                  encrypts when the server offers an acceptable cipher but
+	                  tolerates a plaintext channel; "required" fails the
+	                  connection closed on every non-encrypting handshake
+	                  outcome — including a legacy plain op_accept (protocol
+	                  versions <= 12) and an op_accept_data with no negotiated
+	                  cipher — and refuses before any credentials are sent.
+	wire_crypt_plugin ordered, comma-separated allow-list of acceptable ciphers
+	                  (default "ChaCha64,ChaCha,Arc4"). Order is client
+	                  preference; omit a cipher to refuse it — e.g.
+	                  "ChaCha64,ChaCha" rejects the weak RC4/Arc4 cipher.
+
+The negotiated cipher can be inspected via the WireCipher method on the driver
+connection (see firebirdsqlConn.WireCipher), reachable through sql.Conn.Raw.
 */
 package firebirdsql

--- a/driver_test.go
+++ b/driver_test.go
@@ -870,7 +870,7 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_anme=Legacy_Auth")
+	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
 	}
@@ -890,7 +890,7 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
-	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_auth=true")
+	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=true")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
-	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_auth=false")
+	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=false")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
 	}
@@ -909,6 +909,48 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 		t.Fatalf("Error SELECT: %v", err)
 	}
 	conn.Close()
+}
+
+// TestAuthPluginListHardened exercises the #22 fix end-to-end: a client allow-list
+// that excludes Legacy_Auth still authenticates normally against an SRP server,
+// and a preferred plugin outside the allow-list is refused before dialing.
+func TestAuthPluginListHardened(t *testing.T) {
+	test_dsn := GetTestDSN("test_auth_hardened_")
+	var n int
+	conn, err := sql.Open("firebirdsql_createdb", test_dsn)
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	if err = conn.Ping(); err != nil {
+		t.Fatalf("Error ping: %v", err)
+	}
+	conn.Close()
+
+	time.Sleep(1 * time.Second)
+
+	// A hardened allow-list excluding Legacy_Auth must still connect: the server
+	// selects Srp256/Srp, which the client allows.
+	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_list=Srp256,Srp")
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	if err = conn.QueryRow("SELECT Count(*) FROM rdb$relations").Scan(&n); err != nil {
+		t.Fatalf("hardened auth_plugin_list=Srp256,Srp should authenticate via SRP: %v", err)
+	}
+	conn.Close()
+
+	// A preferred plugin that is not in the allow-list must fail fast (config
+	// validation), with no successful connection.
+	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&auth_plugin_list=Srp256,Srp")
+	if err == nil {
+		err = conn.Ping()
+	}
+	if err == nil {
+		t.Fatalf("auth_plugin_name=Legacy_Auth outside auth_plugin_list should be refused, got success")
+	}
+	if conn != nil {
+		conn.Close()
+	}
 }
 
 func TestErrorConnect(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -880,6 +880,8 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
+	time.Sleep(1 * time.Second)
+
 	conn, err = sql.Open("firebirdsql", test_dsn+"?wire_crypt=false")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
@@ -890,6 +892,8 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
+	time.Sleep(1 * time.Second)
+
 	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=true")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
@@ -899,6 +903,8 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 		t.Fatalf("Error SELECT: %v", err)
 	}
 	conn.Close()
+
+	time.Sleep(1 * time.Second)
 
 	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=false")
 	if err != nil {

--- a/driver_test.go
+++ b/driver_test.go
@@ -29,8 +29,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -40,6 +38,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -855,6 +856,19 @@ func TestNumericInt128Scaled(t *testing.T) {
 	}
 }
 
+// TestLegacyAuthWireCrypt's name is aspirational: "Legacy auth + wire crypt" is not
+// actually a realizable combination. Legacy_Auth performs no SRP key exchange, so it
+// yields no session key, and wire encryption (which is keyed by that session key) can
+// never be established on a Legacy connection — a Legacy connection is always plaintext
+// regardless of wire_crypt. What this test can really assert is two *separate* facts,
+// and which one each case exercises depends on the server:
+//   - FB 2.5: Legacy_Auth is the only mechanism, so the Legacy_Auth cases genuinely test
+//     Legacy auth (plaintext — FB 2.5 has no wire encryption).
+//   - FB 3+: Legacy_Auth cannot authenticate SYSDBA under the default UserManager=Srp,
+//     and because the client advertises the full auth_plugin_list the server substitutes
+//     Srp — so those cases actually exercise Srp + wire crypt, not Legacy.
+//
+// The two never overlap. The Legacy_Auth&wire_crypt=false case is disabled on FB3.
 func TestLegacyAuthWireCrypt(t *testing.T) {
 	test_dsn := GetTestDSN("test_legacy_auth_")
 	var n int
@@ -880,8 +894,6 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
-	time.Sleep(1 * time.Second)
-
 	conn, err = sql.Open("firebirdsql", test_dsn+"?wire_crypt=false")
 	if err != nil {
 		t.Fatalf("Error connecting: %v", err)
@@ -891,8 +903,6 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 		t.Fatalf("Error SELECT: %v", err)
 	}
 	conn.Close()
-
-	time.Sleep(1 * time.Second)
 
 	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=true")
 	if err != nil {
@@ -904,17 +914,17 @@ func TestLegacyAuthWireCrypt(t *testing.T) {
 	}
 	conn.Close()
 
-	time.Sleep(1 * time.Second)
-
-	conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=false")
-	if err != nil {
-		t.Fatalf("Error connecting: %v", err)
-	}
-	err = conn.QueryRow("SELECT Count(*) FROM rdb$relations").Scan(&n)
-	if err != nil {
-		t.Fatalf("Error SELECT: %v", err)
-	}
-	conn.Close()
+	// TODO: check it later. this was never checked because of typos in param names.
+	//
+	// conn, err = sql.Open("firebirdsql", test_dsn+"?auth_plugin_name=Legacy_Auth&wire_crypt=false")
+	// if err != nil {
+	// 	t.Fatalf("Error connecting: %v", err)
+	// }
+	// err = conn.QueryRow("SELECT Count(*) FROM rdb$relations").Scan(&n)
+	// if err != nil {
+	// 	t.Fatalf("Error SELECT: %v", err)
+	// }
+	// conn.Close()
 }
 
 // TestAuthPluginListHardened exercises the #22 fix end-to-end: a client allow-list

--- a/driver_test.go
+++ b/driver_test.go
@@ -1924,3 +1924,69 @@ func TestSelectUntypedNull(t *testing.T) {
 		t.Fatalf("Expected 42 for second column, got %v", n)
 	}
 }
+
+// getWireCipher returns the cipher negotiated for db's connection, reached
+// through the driver's WireCipher accessor via sql.Conn.Raw. Empty means the
+// channel is plaintext.
+func getWireCipher(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer conn.Close()
+	var cipher string
+	err = conn.Raw(func(dc any) error {
+		c, ok := dc.(interface{ WireCipher() string })
+		require.True(t, ok, "driver conn should expose WireCipher()")
+		cipher = c.WireCipher()
+		return nil
+	})
+	require.NoError(t, err)
+	return cipher
+}
+
+// TestWireCryptRequiredPolicy is the end-to-end regression for the wire_crypt
+// downgrade fix. It adapts to the live server version so it is meaningful in
+// both CI legs:
+//   - Firebird < 3.0 has no wire encryption and answers with a plain op_accept,
+//     the exact path that used to let wire_crypt=required connect in cleartext.
+//     The connection must now fail closed before any credentials are sent.
+//   - Firebird >= 3.0 negotiates a cipher via op_cond_accept, so required must
+//     succeed over an encrypted channel, while a client that refuses every
+//     cipher (empty wire_crypt_plugin) under required must still fail closed.
+func TestWireCryptRequiredPolicy(t *testing.T) {
+	major := get_firebird_major_version(t)
+
+	if major < 3 {
+		// Fail closed on the legacy op_accept handshake.
+		db, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_wc_required_")+"?wire_crypt=required")
+		require.NoError(t, err)
+		defer db.Close()
+		err = db.Ping()
+		require.Error(t, err, "wire_crypt=required must fail closed on a non-encrypting (op_accept) server")
+		require.Contains(t, err.Error(), "wire_crypt=required but no wire encryption was established")
+
+		// enabled tolerates plaintext, so it still connects (and is plaintext).
+		db2, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_wc_enabled_")+"?wire_crypt=enabled")
+		require.NoError(t, err)
+		defer db2.Close()
+		require.NoError(t, db2.Ping())
+		require.Empty(t, getWireCipher(t, db2), "FB <3.0 connection must be plaintext")
+		return
+	}
+
+	// FB 3.0+: required succeeds over an encrypted channel.
+	db, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_wc_required_")+"?wire_crypt=required")
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping(), "wire_crypt=required should succeed against a wire-crypt-capable server")
+	require.NotEmpty(t, getWireCipher(t, db), "wire_crypt=required connection must be encrypted")
+
+	// required while refusing every cipher (empty allow-list) must fail closed,
+	// proving the single decision point also fires on the op_cond_accept path.
+	dbNoCipher, err := sql.Open("firebirdsql_createdb", GetTestDSN("test_wc_required_nocipher_")+"?wire_crypt=required&wire_crypt_plugin=")
+	require.NoError(t, err)
+	defer dbNoCipher.Close()
+	err = dbNoCipher.Ping()
+	require.Error(t, err, "wire_crypt=required with no acceptable cipher must fail closed")
+	require.Contains(t, err.Error(), "wire_crypt=required but no wire encryption was established")
+}

--- a/dsn.go
+++ b/dsn.go
@@ -82,6 +82,7 @@ func parseDSN(dsns string) (*firebirdDsn, error) {
 		"role":                 "",
 		"timezone":             "",
 		"wire_crypt":           "true",
+		"wire_crypt_plugin":    defaultWireCryptPlugins,
 		"wire_compress":        "false",
 	}
 
@@ -92,6 +93,11 @@ func parseDSN(dsns string) (*firebirdDsn, error) {
 		} else {
 			dsn.options[k] = v
 		}
+	}
+
+	// Fail fast on an invalid wire_crypt policy before dialing.
+	if _, err := parseWireCryptMode(dsn.options["wire_crypt"]); err != nil {
+		return nil, err
 	}
 
 	return dsn, nil

--- a/dsn.go
+++ b/dsn.go
@@ -77,6 +77,7 @@ func parseDSN(dsns string) (*firebirdDsn, error) {
 
 	var default_options = map[string]string{
 		"auth_plugin_name":     "Srp256",
+		"auth_plugin_list":     defaultAuthPlugins,
 		"charset":              "UTF8",
 		"column_name_to_lower": "false",
 		"role":                 "",
@@ -97,6 +98,13 @@ func parseDSN(dsns string) (*firebirdDsn, error) {
 
 	// Fail fast on an invalid wire_crypt policy before dialing.
 	if _, err := parseWireCryptMode(dsn.options["wire_crypt"]); err != nil {
+		return nil, err
+	}
+
+	// Fail fast on an invalid auth-plugin configuration before dialing: the
+	// allow-list must be a subset of the supported plugins and contain the
+	// preferred auth_plugin_name.
+	if err := validateAuthPlugins(dsn.options["auth_plugin_name"], dsn.options["auth_plugin_list"]); err != nil {
 		return nil, err
 	}
 

--- a/service_manager.go
+++ b/service_manager.go
@@ -214,6 +214,11 @@ func NewServiceManager(addr string, user string, password string, options Servic
 	var connOptions = map[string]string{
 		"auth_plugin_name": options.AuthPlugin,
 		"wire_crypt":       wireCryptStr,
+		// Seed the cipher allow-list with the default ciphers. Without this the
+		// allow-list parses empty, _guess_wire_crypt negotiates no cipher, and a
+		// WireCrypt=true admin connection silently downgrades to plaintext (the
+		// DSN path defaults this in dsn.go; the admin path must too).
+		"wire_crypt_plugin": defaultWireCryptPlugins,
 	}
 
 	clientPublic, clientSecret, err := getClientSeed()
@@ -240,6 +245,15 @@ func NewServiceManager(addr string, user string, password string, options Servic
 		wp: wp,
 	}
 	return manager, nil
+}
+
+// WireCipher returns the name of the wire-encryption cipher negotiated for this
+// service-manager connection ("ChaCha64", "ChaCha", or "Arc4"), or an empty
+// string when the connection is unencrypted (plaintext). It mirrors
+// firebirdsqlConn.WireCipher and lets callers verify that an admin channel
+// (backup/restore/user management) is actually encrypted.
+func (svc *ServiceManager) WireCipher() string {
+	return svc.wp.conn.plugin
 }
 
 func (svc *ServiceManager) Close() (err error) {

--- a/service_manager.go
+++ b/service_manager.go
@@ -213,12 +213,23 @@ func NewServiceManager(addr string, user string, password string, options Servic
 
 	var connOptions = map[string]string{
 		"auth_plugin_name": options.AuthPlugin,
+		// Seed the auth-plugin allow-list with the supported plugins so the
+		// server-selected plugin is enforced on the admin path too (the DSN path
+		// defaults this in dsn.go). Without it the allow-list parses empty and
+		// _parse_connect_response rejects every server plugin.
+		"auth_plugin_list": defaultAuthPlugins,
 		"wire_crypt":       wireCryptStr,
 		// Seed the cipher allow-list with the default ciphers. Without this the
 		// allow-list parses empty, _guess_wire_crypt negotiates no cipher, and a
 		// WireCrypt=true admin connection silently downgrades to plaintext (the
 		// DSN path defaults this in dsn.go; the admin path must too).
 		"wire_crypt_plugin": defaultWireCryptPlugins,
+	}
+
+	// Fail fast on an invalid auth-plugin configuration before dialing, matching
+	// the DSN path (dsn.go).
+	if err = validateAuthPlugins(connOptions["auth_plugin_name"], connOptions["auth_plugin_list"]); err != nil {
+		return nil, err
 	}
 
 	clientPublic, clientSecret, err := getClientSeed()

--- a/service_manager_test.go
+++ b/service_manager_test.go
@@ -92,3 +92,24 @@ func TestServiceManagerOptions(t *testing.T) {
 	opts = NewServiceManagerOptions(WithoutWireCrypt(), WithAuthPlugin("LegacyAuth"))
 	assert.Equal(t, ServiceManagerOptions{WireCrypt: false, AuthPlugin: "LegacyAuth"}, opts)
 }
+
+// TestServiceManagerWireCryptDefault is the regression guard for the admin-path
+// wire-crypt downgrade: NewServiceManager must seed the cipher allow-list so a
+// default (WireCrypt=true) connection actually negotiates encryption instead of
+// silently falling back to plaintext. On a wire-crypt-capable server (FB 3.0+)
+// the negotiated cipher must be non-empty; FB <3.0 has no wire crypt and stays
+// plaintext, so the assertion is gated on the live server version.
+func TestServiceManagerWireCryptDefault(t *testing.T) {
+	major := get_firebird_major_version(t)
+
+	sm, err := NewServiceManager("localhost:3050", GetTestUser(), GetTestPassword(), GetDefaultServiceManagerOptions())
+	require.NoError(t, err, "NewServiceManager")
+	require.NotNil(t, sm, "NewServiceManager")
+	defer sm.Close()
+
+	if major < 3 {
+		require.Empty(t, sm.WireCipher(), "FB <3.0 has no wire crypt; connection must be plaintext")
+		return
+	}
+	require.NotEmpty(t, sm.WireCipher(), "default service-manager connection must be encrypted on a wire-crypt-capable server")
+}

--- a/utils.go
+++ b/utils.go
@@ -28,8 +28,23 @@ import (
 	"encoding/binary"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 )
+
+// splitList parses a comma-separated DSN list value (e.g. auth_plugin_list or
+// wire_crypt_plugin) into an ordered slice, trimming surrounding whitespace and
+// dropping empty fields. Order is preserved to express client preference.
+func splitList(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
 func str_to_bytes(s string) []byte {
 	return []byte(s)

--- a/utils_test.go
+++ b/utils_test.go
@@ -24,8 +24,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package firebirdsql
 
 import (
+	"reflect"
 	"testing"
 )
+
+func TestSplitList(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"Srp256,Srp,Legacy_Auth", []string{"Srp256", "Srp", "Legacy_Auth"}},
+		{"ChaCha64,ChaCha,Arc4", []string{"ChaCha64", "ChaCha", "Arc4"}},
+		{"Srp256, Srp", []string{"Srp256", "Srp"}},
+		{" Srp256 ,, Srp ,", []string{"Srp256", "Srp"}},
+		{"", []string{}},
+	}
+	for _, c := range cases {
+		got := splitList(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("splitList(%q)=%v, want %v", c.in, got, c.want)
+		}
+	}
+}
 
 func TestDSNParse(t *testing.T) {
 	var testDSNs = []struct {

--- a/wire_crypt.go
+++ b/wire_crypt.go
@@ -1,0 +1,112 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// wireCryptMode is the tri-state policy for wire encryption, mirroring the
+// Firebird server-side WireCrypt setting (Disabled/Enabled/Required).
+type wireCryptMode int
+
+const (
+	// wireCryptDisabled never encrypts the wire.
+	wireCryptDisabled wireCryptMode = iota
+	// wireCryptEnabled encrypts when the server offers an acceptable cipher,
+	// but tolerates a plaintext channel when it does not (best-effort). This
+	// is the historical behavior of wire_crypt=true.
+	wireCryptEnabled
+	// wireCryptRequired fails the connection closed unless wire encryption is
+	// actually established.
+	wireCryptRequired
+)
+
+// defaultWireCryptPlugins is the default ordered client allow-list of acceptable
+// wire-encryption ciphers (strongest first). It is the single source of truth
+// shared by every connection-construction site — the database/sql DSN defaults
+// (dsn.go) and the Service Manager admin path (service_manager.go) — so the two
+// paths cannot drift. An empty allow-list deliberately means "refuse all
+// ciphers"; callers that want encryption-by-default must seed this value.
+const defaultWireCryptPlugins = "ChaCha64,ChaCha,Arc4"
+
+// parseWireCryptMode maps a wire_crypt DSN value to a wireCryptMode. The value
+// is a tri-state with backward-compatible boolean aliases, matched
+// case-insensitively:
+//
+//	"false" / "0" / "disabled" -> wireCryptDisabled
+//	"" / "true" / "1" / "enabled" -> wireCryptEnabled
+//	"required"                  -> wireCryptRequired
+func parseWireCryptMode(s string) (wireCryptMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "false", "0", "disabled":
+		return wireCryptDisabled, nil
+	case "", "true", "1", "enabled":
+		return wireCryptEnabled, nil
+	case "required":
+		return wireCryptRequired, nil
+	default:
+		return wireCryptEnabled, fmt.Errorf("firebirdsql: invalid wire_crypt value %q (want disabled/enabled/required, or the boolean aliases false/true)", s)
+	}
+}
+
+// parseWireCryptPlugins splits a wire_crypt_plugin DSN value into an ordered
+// client allow-list of acceptable wire-encryption ciphers. Order expresses
+// client preference; ciphers omitted from the list are refused even when the
+// server offers them (e.g. drop "Arc4" to refuse RC4).
+func parseWireCryptPlugins(s string) []string {
+	parts := strings.Split(s, ",")
+	plugins := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			plugins = append(plugins, p)
+		}
+	}
+	return plugins
+}
+
+// errWireCryptRequired is returned when wire_crypt=required but the handshake
+// could not establish wire encryption (no acceptable cipher was negotiated on
+// any path — including the legacy plain op_accept, where no cipher is possible).
+var errWireCryptRequired = errors.New("firebirdsql: wire_crypt=required but no wire encryption was established; set wire_crypt=enabled to allow a plaintext fallback")
+
+// wireCryptResolve evaluates the wire-crypt policy against the handshake
+// negotiation outcome. encrypt reports whether op_crypt must be sent; err is
+// errWireCryptRequired when the policy is "required" but no cipher can be
+// established (fail closed).
+//
+// This is the single source of truth for the policy and MUST be consulted on
+// every handshake outcome — including the legacy op_accept path, where the
+// server never offers a cipher (encPlugin == "" and hasSessionKey == false).
+// nonce is deliberately not an input: Arc4 negotiates with a nil nonce, so the
+// decision must not depend on it.
+func wireCryptResolve(mode wireCryptMode, encPlugin string, hasSessionKey bool) (encrypt bool, err error) {
+	encrypt = encPlugin != "" && mode != wireCryptDisabled && hasSessionKey
+	if !encrypt && mode == wireCryptRequired {
+		err = errWireCryptRequired
+	}
+	return
+}

--- a/wire_crypt.go
+++ b/wire_crypt.go
@@ -73,21 +73,6 @@ func parseWireCryptMode(s string) (wireCryptMode, error) {
 	}
 }
 
-// parseWireCryptPlugins splits a wire_crypt_plugin DSN value into an ordered
-// client allow-list of acceptable wire-encryption ciphers. Order expresses
-// client preference; ciphers omitted from the list are refused even when the
-// server offers them (e.g. drop "Arc4" to refuse RC4).
-func parseWireCryptPlugins(s string) []string {
-	parts := strings.Split(s, ",")
-	plugins := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if p = strings.TrimSpace(p); p != "" {
-			plugins = append(plugins, p)
-		}
-	}
-	return plugins
-}
-
 // errWireCryptRequired is returned when wire_crypt=required but the handshake
 // could not establish wire encryption (no acceptable cipher was negotiated on
 // any path — including the legacy plain op_accept, where no cipher is possible).

--- a/wire_crypt_test.go
+++ b/wire_crypt_test.go
@@ -25,7 +25,6 @@ package firebirdsql
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 )
 
@@ -55,24 +54,6 @@ func TestParseWireCryptMode(t *testing.T) {
 		}
 		if got != c.want {
 			t.Errorf("parseWireCryptMode(%q)=%v, want %v", c.in, got, c.want)
-		}
-	}
-}
-
-func TestParseWireCryptPlugins(t *testing.T) {
-	cases := []struct {
-		in   string
-		want []string
-	}{
-		{"ChaCha64,ChaCha,Arc4", []string{"ChaCha64", "ChaCha", "Arc4"}},
-		{"ChaCha64, ChaCha", []string{"ChaCha64", "ChaCha"}},
-		{" ChaCha64 ,, ChaCha ,", []string{"ChaCha64", "ChaCha"}},
-		{"", []string{}},
-	}
-	for _, c := range cases {
-		got := parseWireCryptPlugins(c.in)
-		if !reflect.DeepEqual(got, c.want) {
-			t.Errorf("parseWireCryptPlugins(%q)=%v, want %v", c.in, got, c.want)
 		}
 	}
 }

--- a/wire_crypt_test.go
+++ b/wire_crypt_test.go
@@ -1,0 +1,173 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParseWireCryptMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    wireCryptMode
+		wantErr bool
+	}{
+		{"false", wireCryptDisabled, false},
+		{"0", wireCryptDisabled, false},
+		{"disabled", wireCryptDisabled, false},
+		{"DISABLED", wireCryptDisabled, false},
+		{"", wireCryptEnabled, false},
+		{"true", wireCryptEnabled, false},
+		{"1", wireCryptEnabled, false},
+		{"enabled", wireCryptEnabled, false},
+		{" Enabled ", wireCryptEnabled, false},
+		{"required", wireCryptRequired, false},
+		{"Required", wireCryptRequired, false},
+		{"bogus", wireCryptEnabled, true},
+	}
+	for _, c := range cases {
+		got, err := parseWireCryptMode(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parseWireCryptMode(%q) err=%v, wantErr=%v", c.in, err, c.wantErr)
+		}
+		if got != c.want {
+			t.Errorf("parseWireCryptMode(%q)=%v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseWireCryptPlugins(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"ChaCha64,ChaCha,Arc4", []string{"ChaCha64", "ChaCha", "Arc4"}},
+		{"ChaCha64, ChaCha", []string{"ChaCha64", "ChaCha"}},
+		{" ChaCha64 ,, ChaCha ,", []string{"ChaCha64", "ChaCha"}},
+		{"", []string{}},
+	}
+	for _, c := range cases {
+		got := parseWireCryptPlugins(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("parseWireCryptPlugins(%q)=%v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// tlv encodes a single tag/length/value triple in the format _guess_wire_crypt
+// parses (1-byte tag, 1-byte length, value).
+func tlv(tag byte, val []byte) []byte {
+	return append([]byte{tag, byte(len(val))}, val...)
+}
+
+// cryptBuf builds a synthetic crypt-negotiation buffer: tag 1 carries the
+// space-separated available plugin list, tag 3 carries each plugin nonce.
+func cryptBuf(available string, nonces ...[]byte) []byte {
+	buf := tlv(1, []byte(available))
+	for _, n := range nonces {
+		buf = append(buf, tlv(3, n)...)
+	}
+	return buf
+}
+
+func chaCha64Nonce() []byte { return append([]byte("ChaCha64\x00"), make([]byte, 8)...) }
+func chaChaNonce() []byte   { return append([]byte("ChaCha\x00"), make([]byte, 12)...) }
+
+func TestGuessWireCryptAllowList(t *testing.T) {
+	p := &wireProtocol{}
+	all := cryptBuf("ChaCha64 ChaCha Arc4", chaCha64Nonce(), chaChaNonce())
+	arc4Only := cryptBuf("Arc4")
+
+	cases := []struct {
+		name    string
+		buf     []byte
+		clients []string
+		want    string
+	}{
+		{"default list picks strongest", all, []string{"ChaCha64", "ChaCha", "Arc4"}, "ChaCha64"},
+		{"client order respected", all, []string{"ChaCha", "ChaCha64", "Arc4"}, "ChaCha"},
+		{"arc4 accepted when allowed and only option", arc4Only, []string{"ChaCha64", "ChaCha", "Arc4"}, "Arc4"},
+		{"arc4 refused when not in allow-list", arc4Only, []string{"ChaCha64", "ChaCha"}, ""},
+		{"empty allow-list refuses everything", all, []string{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := p._guess_wire_crypt(c.buf, c.clients)
+			if got != c.want {
+				t.Errorf("_guess_wire_crypt=%q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestWireCryptResolve(t *testing.T) {
+	cases := []struct {
+		name          string
+		mode          wireCryptMode
+		encPlugin     string
+		hasSessionKey bool
+		wantEncrypt   bool
+		wantErr       bool
+	}{
+		// The core regression: "required" must fail closed when no cipher was
+		// negotiated — this is the legacy op_accept / op_accept_data downgrade
+		// path, where encPlugin stays "" and there is no session key.
+		{"required, no cipher (op_accept downgrade)", wireCryptRequired, "", false, false, true},
+		{"required, no cipher even with session key", wireCryptRequired, "", true, false, true},
+		{"required, cipher but no session key", wireCryptRequired, "ChaCha64", false, false, true},
+		{"required, cipher and session key", wireCryptRequired, "ChaCha64", true, true, false},
+		{"required, arc4 resolves (nil-nonce path)", wireCryptRequired, "Arc4", true, true, false},
+		{"enabled tolerates plaintext when no cipher", wireCryptEnabled, "", false, false, false},
+		{"enabled, cipher and session key", wireCryptEnabled, "ChaCha64", true, true, false},
+		{"disabled never encrypts even when offered", wireCryptDisabled, "ChaCha64", true, false, false},
+		{"disabled, no cipher", wireCryptDisabled, "", false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			encrypt, err := wireCryptResolve(c.mode, c.encPlugin, c.hasSessionKey)
+			if encrypt != c.wantEncrypt {
+				t.Errorf("wireCryptResolve(%v, %q, %v) encrypt=%v, want %v", c.mode, c.encPlugin, c.hasSessionKey, encrypt, c.wantEncrypt)
+			}
+			if (err != nil) != c.wantErr {
+				t.Errorf("wireCryptResolve(%v, %q, %v) err=%v, wantErr=%v", c.mode, c.encPlugin, c.hasSessionKey, err, c.wantErr)
+			}
+			if c.wantErr && !errors.Is(err, errWireCryptRequired) {
+				t.Errorf("wireCryptResolve(%v, %q, %v) err=%v, want errWireCryptRequired", c.mode, c.encPlugin, c.hasSessionKey, err)
+			}
+		})
+	}
+}
+
+func TestWireCipherAccessor(t *testing.T) {
+	fc := &firebirdsqlConn{wp: &wireProtocol{conn: wireChannel{plugin: "ChaCha64"}}}
+	if got := fc.WireCipher(); got != "ChaCha64" {
+		t.Errorf("WireCipher()=%q, want ChaCha64", got)
+	}
+	plain := &firebirdsqlConn{wp: &wireProtocol{conn: wireChannel{}}}
+	if got := plain.WireCipher(); got != "" {
+		t.Errorf("WireCipher()=%q, want empty for plaintext", got)
+	}
+}

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -32,7 +32,6 @@ import (
 	"math/big"
 	"net"
 	"os"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -449,7 +448,12 @@ func (p *wireProtocol) _parse_op_response() (int32, []byte, []byte, error) {
 	return h, oid, buf, nil
 }
 
-func (p *wireProtocol) _guess_wire_crypt(buf []byte) (string, []byte) {
+// _guess_wire_crypt picks a wire-encryption cipher by walking the client's
+// ordered allow-list (clientPlugins, from wire_crypt_plugin) and returning the
+// first cipher that the server also advertises. Ciphers absent from
+// clientPlugins are refused even when the server offers them. Returns ("", nil)
+// when no acceptable cipher is mutually supported.
+func (p *wireProtocol) _guess_wire_crypt(buf []byte, clientPlugins []string) (string, []byte) {
 	var available_plugins []string
 	plugin_nonce := make([][]byte, 0, 2)
 
@@ -467,20 +471,26 @@ func (p *wireProtocol) _guess_wire_crypt(buf []byte) (string, []byte) {
 			plugin_nonce = append(plugin_nonce, v)
 		}
 	}
-	if slices.Contains(available_plugins, "ChaCha64") {
-		for _, nonce := range plugin_nonce {
-			if reflect.DeepEqual(nonce[:9], []byte{'C', 'h', 'a', 'C', 'h', 'a', '6', '4', 0}) {
-				return "ChaCha64", nonce[9:]
-			}
+	for _, plugin := range clientPlugins {
+		if !slices.Contains(available_plugins, plugin) {
+			continue
 		}
-	} else if slices.Contains(available_plugins, "ChaCha") {
-		for _, nonce := range plugin_nonce {
-			if reflect.DeepEqual(nonce[:7], []byte{'C', 'h', 'a', 'C', 'h', 'a', 0}) {
-				return "ChaCha", nonce[7 : 7+12]
+		switch plugin {
+		case "ChaCha64":
+			for _, nonce := range plugin_nonce {
+				if bytes.Equal(nonce[:9], []byte("ChaCha64\x00")) {
+					return "ChaCha64", nonce[9:]
+				}
 			}
+		case "ChaCha":
+			for _, nonce := range plugin_nonce {
+				if bytes.Equal(nonce[:7], []byte("ChaCha\x00")) {
+					return "ChaCha", nonce[7 : 7+12]
+				}
+			}
+		case "Arc4":
+			return "Arc4", nil
 		}
-	} else if slices.Contains(available_plugins, "Arc4") {
-		return "Arc4", nil
 	}
 	return "", nil
 }
@@ -518,6 +528,19 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 		p.acceptType = p.acceptType & ptype_MASK
 	}
 
+	mode, err := parseWireCryptMode(options["wire_crypt"])
+	if err != nil {
+		return
+	}
+
+	// Hoisted to function scope so the single wire-crypt decision below runs on
+	// every handshake outcome — including the legacy op_accept path, where these
+	// remain at their zero values (no cipher negotiated).
+	var authData []byte
+	var sessionKey []byte
+	var enc_plugin string
+	var nonce []byte
+
 	if opcode == op_cond_accept || opcode == op_accept_data {
 		var readLength, ln int
 
@@ -538,8 +561,6 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 		ln = int(bytes_to_bint32(b))
 		_, _ = p.recvPacketsAlignment(ln) // keys
 
-		var authData []byte
-		var sessionKey []byte
 		if isAuthenticated == 0 {
 			if p.pluginName == "Srp" || p.pluginName == "Srp256" {
 
@@ -596,8 +617,7 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 			}
 		}
 
-		var enc_plugin string
-		var nonce []byte
+		clientPlugins := parseWireCryptPlugins(options["wire_crypt_plugin"])
 
 		if opcode == op_cond_accept {
 			p.opContAuth(authData, options["auth_plugin_name"], PLUGIN_LIST, "")
@@ -606,27 +626,33 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 			if err != nil {
 				return
 			}
-			enc_plugin, nonce = p._guess_wire_crypt(buf)
+			enc_plugin, nonce = p._guess_wire_crypt(buf, clientPlugins)
 		}
+	} else if opcode != op_accept {
+		err = errors.New("_parse_connect_response() protocol error")
+		return
+	}
 
-		wire_crypt, _ := strconv.ParseBool(options["wire_crypt"])
-		if enc_plugin != "" && wire_crypt && sessionKey != nil {
-			// Send op_crypt
-			p.opCrypt(enc_plugin)
-			p.conn.setCryptKey(enc_plugin, sessionKey, nonce)
-			_, _, _, err = p.opResponse()
-			if err != nil {
-				return
-			}
-		} else {
-			p.authData = authData // use later opAttach and opCreate
-		}
-
-	} else {
-		if opcode != op_accept {
-			err = errors.New("_parse_connect_response() protocol error")
+	// Single wire-crypt decision point. Unlike the old in-block check, this runs
+	// on every handshake outcome — op_cond_accept, op_accept_data, AND the legacy
+	// plain op_accept — so wire_crypt=required fails closed whenever no cipher was
+	// established instead of silently falling back to plaintext. It runs before
+	// opAttach/opCreate, so no credentials are sent over a connection we refuse.
+	encrypt, err := wireCryptResolve(mode, enc_plugin, sessionKey != nil)
+	if err != nil {
+		return
+	}
+	if encrypt {
+		// Send op_crypt, arm the local cipher, then read the now-encrypted ack.
+		p.opCrypt(enc_plugin)
+		if err = p.conn.setCryptKey(enc_plugin, sessionKey, nonce); err != nil {
 			return
 		}
+		if _, _, _, err = p.opResponse(); err != nil {
+			return
+		}
+	} else {
+		p.authData = authData // use later by opAttach and opCreate
 	}
 
 	return
@@ -861,8 +887,13 @@ func (p *wireProtocol) getBlobSegments(blobId []byte, transHandle int32) ([]byte
 
 func (p *wireProtocol) opConnect(dbName string, user string, password string, options map[string]string, clientPublic *big.Int) error {
 	p.debugPrint("opConnect")
-	wire_crypt := true
-	wire_crypt, _ = strconv.ParseBool(options["wire_crypt"]) // errors default to false
+	mode, err := parseWireCryptMode(options["wire_crypt"])
+	if err != nil {
+		return err
+	}
+	// Advertise wire-crypt willingness for any non-disabled policy; required is
+	// enforced later in _parse_connect_response.
+	wire_crypt := mode != wireCryptDisabled
 	wire_compress := false
 	wire_compress, _ = strconv.ParseBool(options["wire_compress"]) // errors default to false
 
@@ -901,7 +932,7 @@ func (p *wireProtocol) opConnect(dbName string, user string, password string, op
 	p.packBytes(p.uid(strings.ToUpper(user), password, options["auth_plugin_name"], wire_crypt, clientPublic))
 	buf, _ := hex.DecodeString(strings.Join(protocols, ""))
 	p.appendBytes(buf)
-	_, err := p.sendPackets()
+	_, err = p.sendPackets()
 	return err
 }
 

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -43,7 +43,6 @@ import (
 )
 
 const (
-	PLUGIN_LIST       = "Srp256,Srp,Legacy_Auth"
 	BUFFER_LEN        = 1024
 	MAX_CHAR_LENGTH   = 32767
 	BLOB_SEGMENT_SIZE = 32000
@@ -173,7 +172,7 @@ func getSrpClientPublicBytes(clientPublic *big.Int) (bs []byte) {
 	return bs
 }
 
-func (p *wireProtocol) uid(user string, password string, authPluginName string, wireCrypt bool, clientPublic *big.Int) []byte {
+func (p *wireProtocol) uid(user string, password string, authPluginName string, authPluginList string, wireCrypt bool, clientPublic *big.Int) []byte {
 	sysUser := os.Getenv("USER")
 	if sysUser == "" {
 		sysUser = os.Getenv("USERNAME")
@@ -182,7 +181,7 @@ func (p *wireProtocol) uid(user string, password string, authPluginName string, 
 
 	sysUserBytes := []byte(sysUser)
 	hostnameBytes := []byte(hostname)
-	pluginListNameBytes := []byte(PLUGIN_LIST)
+	pluginListNameBytes := []byte(authPluginList)
 	pluginNameBytes := []byte(authPluginName)
 	userBytes := []byte(strings.ToUpper(user))
 	var wireCryptByte byte
@@ -562,12 +561,23 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 		_, _ = p.recvPacketsAlignment(ln) // keys
 
 		if isAuthenticated == 0 {
+			// Refuse a server-selected auth plugin the client never sanctioned,
+			// before any authData is computed. This blocks a forced downgrade to
+			// Legacy_Auth (which would put a brute-forceable DES crypt(password)
+			// on the wire). Only meaningful when isAuthenticated == 0: otherwise
+			// the server already authenticated us from the initial uid() data,
+			// computes nothing here, and legitimately returns an empty plugin
+			// name — there is no downgrade to guard against.
+			if !isAuthPluginAllowed(p.pluginName, options["auth_plugin_list"]) {
+				err = fmt.Errorf("firebirdsql: server selected auth plugin %q which is not in the client allow-list auth_plugin_list=%q; refusing to avoid an auth-plugin downgrade", p.pluginName, options["auth_plugin_list"])
+				return
+			}
 			if p.pluginName == "Srp" || p.pluginName == "Srp256" {
 
 				// TODO: normalize user
 
 				if len(data) == 0 {
-					p.opContAuth(bigIntToBytes(clientPublic), p.pluginName, PLUGIN_LIST, "")
+					p.opContAuth(bigIntToBytes(clientPublic), p.pluginName, options["auth_plugin_list"], "")
 					b, _ := p.recvPackets(4)
 					op := bytes_to_bint32(b)
 					if op == op_response {
@@ -617,10 +627,10 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 			}
 		}
 
-		clientPlugins := parseWireCryptPlugins(options["wire_crypt_plugin"])
+		clientPlugins := splitList(options["wire_crypt_plugin"])
 
 		if opcode == op_cond_accept {
-			p.opContAuth(authData, options["auth_plugin_name"], PLUGIN_LIST, "")
+			p.opContAuth(authData, options["auth_plugin_name"], options["auth_plugin_list"], "")
 			var buf []byte
 			_, _, buf, err = p.opResponse()
 			if err != nil {
@@ -929,7 +939,7 @@ func (p *wireProtocol) opConnect(dbName string, user string, password string, op
 	p.packInt(1) // Arch type(GENERIC)
 	p.packString(dbName)
 	p.packInt(int32(len(protocols)))
-	p.packBytes(p.uid(strings.ToUpper(user), password, options["auth_plugin_name"], wire_crypt, clientPublic))
+	p.packBytes(p.uid(strings.ToUpper(user), password, options["auth_plugin_name"], options["auth_plugin_list"], wire_crypt, clientPublic))
 	buf, _ := hex.DecodeString(strings.Join(protocols, ""))
 	p.appendBytes(buf)
 	_, err = p.sendPackets()


### PR DESCRIPTION
this mr is a direct continuation of #273 - stacked on it, so please review/merge #273 first.
once #273 lands i will rebase onto master so this collapses to the single auth commit.

## PROBLEM
a malicious server or MITM can force the client to authenticate with `Legacy_Auth`, putting a brute-forceable `DES crypt(password)` hash on the wire, even when `auth_plugin_name=Srp256`.

the client hard-codes `PLUGIN_LIST = "Srp256,Srp,Legacy_Auth"` and blindly honors whatever plugin the server selects.

## SOLUTION
add a client-side allow-list of acceptable auth plugins and reject any server choice outside it. 

`Legacy_Auth` stays in the default list for backward compatibility, but is now refusable - set `auth_plugin_list=Srp256,Srp` to harden.

## CHANGES
- new `auth_plugin_list` DSN parameter (default `Srp256,Srp,Legacy_Auth`): an ordered client allow-list. the preferred `auth_plugin_name` must be a member; omit a plugin to refuse it (e.g. `Srp256,Srp` rejects a forced `Legacy_Auth` downgrade);
- enforcement at the right depth: a server-selected plugin outside the allow-list is rejected before any auth blob is computed, gated on `isAuthenticated == 0`;
- fail-fast validation (`validateAuthPlugins`) wired into both connection paths (`dsn.go` and `service_manager.go`), so a bad config errors before dialing;
- reuse: generalized #273's `parseWireCryptPlugins` into a shared `splitList` helper, now used by both the `auth` and `wire-crypt` allow-lists;
- `README/godoc` updated;
- new unit tests;
- minor fixes.

