### PR TITLE
fix: close prepared statement when Exec returns an error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -105,14 +105,9 @@ func (fc *firebirdsqlConn) exec(ctx context.Context, query string, args []driver
 	if err != nil {
 		return
 	}
+	defer stmt.Close()
 
 	result, err = stmt.(*firebirdsqlStmt).exec(ctx, args)
-	if err != nil {
-		return
-	}
-
-	stmt.Close()
-
 	return
 }
 

--- a/stmt_leak_test.go
+++ b/stmt_leak_test.go
@@ -1,0 +1,63 @@
+package firebirdsql
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecStatementLeakOnError guards against a regression where
+// (*firebirdsqlConn).exec returns without calling stmt.Close() when
+// stmt.exec() reports an error. Without the close, the prepared
+// statement stays allocated on the server until the whole attachment
+// is detached.
+//
+// Reproduction strategy: trigger N duplicate-key INSERTs against a
+// UNIQUE column. Each Exec fails with FbError. After that, count how
+// many prepared statements referencing our table are still alive on
+// the server via the MON$STATEMENTS monitoring table.
+func TestExecStatementLeakOnError(t *testing.T) {
+	file, dsn, err := CreateTestDatabase("test_exec_leak_")
+	require.NoError(t, err)
+	defer os.Remove(file)
+
+	conn, err := sql.Open("firebirdsql", dsn)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// pin a single physical attachment so every Exec reuses the same
+	// underlying conn. Otherwise, leaked statements could be reaped when
+	// the pool closes their conn, masking the leak.
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+
+	_, err = conn.Exec("CREATE TABLE leak_test (id INTEGER NOT NULL PRIMARY KEY)")
+	require.NoError(t, err)
+	_, err = conn.Exec("INSERT INTO leak_test VALUES (1)")
+	require.NoError(t, err)
+
+	const N = 30
+	for i := 0; i < N; i++ {
+		_, err := conn.Exec("INSERT INTO leak_test VALUES (1)") // duplicate PK
+		require.Error(t, err, "iter %d: expected duplicate-key error", i)
+	}
+
+	// count prepared statements still allocated for the current
+	// attachment whose SQL text references leak_test. The MON$STATEMENTS
+	// query itself is excluded.
+	var leaked int
+	err = conn.QueryRow(`
+		SELECT COUNT(*) FROM MON$STATEMENTS
+		WHERE MON$ATTACHMENT_ID = CURRENT_CONNECTION
+		  AND MON$SQL_TEXT CONTAINING 'leak_test'
+		  AND MON$SQL_TEXT NOT CONTAINING 'MON$STATEMENTS'
+	`).Scan(&leaked)
+	require.NoError(t, err)
+
+	t.Logf("Leaked prepared statements after %d failing Exec()s: %d", N, leaked)
+	assert.Equal(t, 0, leaked,
+		"Exec() leaks the prepared statement handle when the statement returns an error")
+}


### PR DESCRIPTION
`(*firebirdsqlConn).exec` returns without calling `stmt.Close()` when
`stmt.exec()` reports an error. the prepared statement stays allocated on
the server until the whole attachment is detached.

## PROBLEM
on long-lived pooled connections with any non-trivial error rate
(constraint violations, deadlocks, type conversion errors, etc.) the
leaked handles accumulate per attachment. `MON$STATEMENTS` for that
attachment grows; server memory follows.

related to #238, which introduced the `closeStmtOnClose` flag for the
success path of `query()`. the error path of `exec()` was missed.

## CHANGES
- `connection.go`: replace explicit `stmt.Close()` at the end of `exec()`
  with `defer stmt.Close()` right after the prepare. the close now runs
  on every exit path, including the error return from `stmt.exec()`.
- add `TestExecStatementLeakOnError` that triggers 30 duplicate-key
  inserts and asserts via `MON$STATEMENTS` that no statements are left
  allocated on the attachment.

## WINS
- no server-side handle leak on Exec error.
- test fails on master, passes after the fix.