### PR TITLE
fix: bounds-check server handshake data in _guess_wire_crypt and handle opCrypt send error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -114,15 +114,12 @@ func (fc *firebirdsqlConn) Prepare(query string) (driver.Stmt, error) {
 // ============ driver.Tx implementation
 
 func (fc *firebirdsqlConn) exec(ctx context.Context, query string, args []driver.Value) (result driver.Result, err error) {
-
 	stmt, err := fc.prepare(ctx, query)
 	if err != nil {
 		return
 	}
 	defer stmt.Close()
-
-	result, err = stmt.(*firebirdsqlStmt).exec(ctx, args)
-	return
+	return stmt.(*firebirdsqlStmt).exec(ctx, args)
 }
 
 func (fc *firebirdsqlConn) Exec(query string, args []driver.Value) (result driver.Result, err error) {

--- a/wire_crypt_test.go
+++ b/wire_crypt_test.go
@@ -104,6 +104,53 @@ func TestGuessWireCryptAllowList(t *testing.T) {
 	}
 }
 
+// TestGuessWireCryptMalformedInput exercises the bounds guards in
+// _guess_wire_crypt against server-controlled handshake bytes. Every case must
+// return ("", nil) WITHOUT panicking — a malformed/truncated nonce or TLV record
+// from a malicious server must not crash the client (remote DoS). The well-formed
+// and allow-list-refusal paths are covered by TestGuessWireCryptAllowList.
+func TestGuessWireCryptMalformedInput(t *testing.T) {
+	p := &wireProtocol{}
+	clients := []string{"ChaCha64", "ChaCha", "Arc4"}
+
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"empty buffer", nil},
+		{"chacha64 nonce shorter than 9-byte prefix",
+			cryptBuf("ChaCha64", []byte("ChaCha6"))},
+		{"chacha nonce shorter than prefix",
+			cryptBuf("ChaCha", []byte("ChaC"))},
+		{"chacha nonce prefix present but IV truncated",
+			cryptBuf("ChaCha", []byte("ChaCha\x00short"))}, // 12 bytes total — prefix OK but IV short of 7+12
+		{"tlv length runs past end of buffer",
+			[]byte{1, 6, 'C', 'h', 'a', 'C', 'h'}}, // claims 6, only 5 follow
+		{"dangling tag byte with no length",
+			append(cryptBuf("ChaCha"), 3)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// A panic here is a test failure (the guards are missing).
+			got, nonce := p._guess_wire_crypt(c.buf, clients)
+			if got != "" || nonce != nil {
+				t.Errorf("_guess_wire_crypt=%q (nonce len %d), want \"\" / nil", got, len(nonce))
+			}
+		})
+	}
+}
+
+// TestGuessWireCryptSkipsTruncatedNonce verifies a short nonce is skipped
+// (continue, not break): a valid nonce later in the list must still be found.
+func TestGuessWireCryptSkipsTruncatedNonce(t *testing.T) {
+	p := &wireProtocol{}
+	buf := cryptBuf("ChaCha", []byte("ChaCha\x00short"), chaChaNonce())
+	got, nonce := p._guess_wire_crypt(buf, []string{"ChaCha"})
+	if got != "ChaCha" || len(nonce) != 12 {
+		t.Errorf("_guess_wire_crypt=%q (nonce len %d), want ChaCha / 12", got, len(nonce))
+	}
+}
+
 func TestWireCryptResolve(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -456,12 +456,21 @@ func (p *wireProtocol) _guess_wire_crypt(buf []byte, clientPlugins []string) (st
 	var available_plugins []string
 	plugin_nonce := make([][]byte, 0, 2)
 
-	i := 0
-	for i = 0; i < len(buf); {
+	// buf is server-controlled handshake data; bounds-check every read so a
+	// malformed/truncated record cannot panic the client (remote DoS). On any
+	// malformed record we stop parsing and proceed with whatever was validly
+	// parsed so far — which falls through to ("", nil) when nothing usable.
+	for i := 0; i < len(buf); {
 		t := buf[i]
 		i++
+		if i >= len(buf) {
+			break // missing length byte
+		}
 		ln := int(buf[i])
 		i++
+		if i+ln > len(buf) {
+			break // value runs past end of buffer
+		}
 		v := buf[i : i+ln]
 		i += ln
 		if t == 1 {
@@ -477,12 +486,20 @@ func (p *wireProtocol) _guess_wire_crypt(buf []byte, clientPlugins []string) (st
 		switch plugin {
 		case "ChaCha64":
 			for _, nonce := range plugin_nonce {
+				if len(nonce) < 9 {
+					continue // too short for the "ChaCha64\x00" prefix
+				}
 				if bytes.Equal(nonce[:9], []byte("ChaCha64\x00")) {
+					// variable-length IV; validated downstream by
+					// setCryptKey -> chacha20.NewCipher (errors, not panics)
 					return "ChaCha64", nonce[9:]
 				}
 			}
 		case "ChaCha":
 			for _, nonce := range plugin_nonce {
+				if len(nonce) < 7+12 {
+					continue // too short for "ChaCha\x00" prefix + 12-byte IV
+				}
 				if bytes.Equal(nonce[:7], []byte("ChaCha\x00")) {
 					return "ChaCha", nonce[7 : 7+12]
 				}
@@ -654,7 +671,11 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 	}
 	if encrypt {
 		// Send op_crypt, arm the local cipher, then read the now-encrypted ack.
-		p.opCrypt(enc_plugin)
+		// If op_crypt fails to send, bail before arming local crypto — otherwise
+		// we would try to parse an unencrypted server response as encrypted.
+		if err = p.opCrypt(enc_plugin); err != nil {
+			return
+		}
 		if err = p.conn.setCryptKey(enc_plugin, sessionKey, nonce); err != nil {
 			return
 		}


### PR DESCRIPTION
follow-up fixes to #273/#274/#275. 
- _guess_wire_crypt: a malformed/truncated handshake from a malicious server or MITM;
- could panic the client (remote DoS), every read is now bounds-checked, a short nonce is skipped rather than treated as fatal, so a valid nonce later in the list still negotiates;
- fail fast on opCrypt()'s send error;
- new tests;
- minor fixes.
