### PR TITLE
fix(cancel): bound teardown reads and evict desynced conns on context cancellation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -87,7 +87,9 @@ func (fc *firebirdsqlConn) Close() (err error) {
 	if err != nil {
 		return
 	}
-	_, _, _, err = fc.wp.opResponse()
+	// Teardown read: bounded so pool eviction (database/sql closing a conn flagged
+	// ErrBadConn) cannot hang on a silent wire.
+	_, _, _, err = fc.wp.opResponseTimeout(abandonReadTimeout)
 	fc.wp.conn.Close()
 	return
 }

--- a/dirtyconn_test.go
+++ b/dirtyconn_test.go
@@ -1,0 +1,244 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2025 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stallProxy is a transparent TCP proxy: client->server bytes always flow, but server->client
+// bytes are held while "stalled". This makes the driver's OS-deadline fallback path (the rare
+// Go-timer-starvation case the cancellation hardening defends against) deterministic — the
+// client's conn.SetDeadline still fires through the stall while the server's response is
+// withheld.
+type stallProxy struct {
+	ln      net.Listener
+	backend string
+	mu      sync.Mutex
+	cond    *sync.Cond
+	stalled bool
+}
+
+func newStallProxy(backend string) (*stallProxy, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	p := &stallProxy{ln: ln, backend: backend}
+	p.cond = sync.NewCond(&p.mu)
+	go p.acceptLoop()
+	return p, nil
+}
+
+func (p *stallProxy) addr() string { return p.ln.Addr().String() }
+func (p *stallProxy) close()       { p.ln.Close() }
+
+func (p *stallProxy) stall() {
+	p.mu.Lock()
+	p.stalled = true
+	p.mu.Unlock()
+}
+
+func (p *stallProxy) release() {
+	p.mu.Lock()
+	p.stalled = false
+	p.cond.Broadcast()
+	p.mu.Unlock()
+}
+
+func (p *stallProxy) waitWhileStalled() {
+	p.mu.Lock()
+	for p.stalled {
+		p.cond.Wait()
+	}
+	p.mu.Unlock()
+}
+
+func (p *stallProxy) acceptLoop() {
+	for {
+		c, err := p.ln.Accept()
+		if err != nil {
+			return
+		}
+		go p.handle(c)
+	}
+}
+
+func (p *stallProxy) handle(client net.Conn) {
+	server, err := net.Dial("tcp", p.backend)
+	if err != nil {
+		client.Close()
+		return
+	}
+	go func() { // client -> server: always flows
+		buf := make([]byte, 64*1024)
+		for {
+			n, rerr := client.Read(buf)
+			if n > 0 {
+				if _, werr := server.Write(buf[:n]); werr != nil {
+					break
+				}
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		server.Close()
+	}()
+	buf := make([]byte, 64*1024) // server -> client: gated by the stall
+	for {
+		n, rerr := server.Read(buf)
+		if n > 0 {
+			p.waitWhileStalled()
+			if _, werr := client.Write(buf[:n]); werr != nil {
+				break
+			}
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	client.Close()
+}
+
+// TestDirtyConnCancellation drives the cancellation dirty-connection fixes through a stalling
+// TCP proxy in front of a live Firebird server. With the server's responses held, a
+// QueryContext deadline that fires mid-fetch must:
+//
+//	teardown bound  not hang the *automatic* rows-close (database/sql's awaitDone ->
+//	                rows.Close() -> freeStatement) on the silent wire — every teardown
+//	                opResponse is now OS-deadline bounded, so the call returns from the
+//	                deadlines, not from the stall release.
+//	conn eviction   leave the desynced connection *evicted*, not pooled — rows.Next wraps
+//	                driver.ErrBadConn on ctx expiry, so a fresh query on the same *sql.DB
+//	                succeeds instead of reading the leftover fetch bytes where it expects
+//	                op_response ("Error op_response:1").
+//
+// Gated to Firebird 3.0+ (matching TestQueryContextCancelRace): op_cancel semantics differ on
+// FB 2.5 and its SuperServer wedges under this connection churn.
+func TestDirtyConnCancellation(t *testing.T) {
+	_, realDSN, err := CreateTestDatabase("test_dirtyconn_")
+	if err != nil {
+		t.Fatalf("create test database: %v", err)
+	}
+	time.Sleep(1 * time.Second) // match the repo's create->attach settle
+
+	proxy, err := newStallProxy("localhost:3050")
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	defer proxy.close()
+	proxyDSN := strings.Replace(realDSN, "localhost:3050", proxy.addr(), 1)
+
+	db, err := sql.Open("firebirdsql", proxyDSN)
+	if err != nil {
+		t.Fatalf("open through proxy: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping through proxy: %v", err)
+	}
+	if engineMajorVersion(db) < 3 {
+		t.Skip("requires Firebird 3.0+ (op_cancel cancellation semantics; FB 2.5 SuperServer wedges under connection churn)")
+	}
+
+	// Shorten the teardown bound so the test exercises the several sequential stalled reads
+	// (freeStatement, commit-retaining, rollback, detach) quickly; production default is 10s.
+	// Package tests run without t.Parallel, so this global override is safe and restored below.
+	defer func(orig time.Duration) { abandonReadTimeout = orig }(abandonReadTimeout)
+	abandonReadTimeout = 2 * time.Second
+
+	const stallRelease = 40 * time.Second
+	// A selectable execute block: rows arrive via cursor fetch, so the stall lands on the
+	// fetch response (not the execute ack).
+	const twoRowSelect = `execute block returns (i integer) as begin i = 1; suspend; i = 2; suspend; end`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, twoRowSelect)
+	if err != nil {
+		// Deadline occasionally fires during execute (before any rows) — that path is already
+		// covered by 6f05210 and isn't what this test targets.
+		t.Skipf("deadline fired during execute, not fetch: %v", err)
+	}
+
+	// Stall AFTER the execute response, BEFORE the first fetch; release well later so we can
+	// distinguish "returned because the deadlines fired" from "returned only on release".
+	proxy.stall()
+	releaseTimer := time.AfterFunc(stallRelease, proxy.release)
+	defer releaseTimer.Stop()
+	defer proxy.release()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		for rows.Next() {
+			var v int
+			_ = rows.Scan(&v)
+		}
+		cerr := rows.Err()
+		rows.Close() // reached automatically via awaitDone too; calling it explicitly is fine
+		done <- cerr
+	}()
+
+	var iterErr error
+	select {
+	case iterErr = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("rows iteration/close hung > 30s on the stalled wire: a teardown opResponse is not bounded")
+	}
+	elapsed := time.Since(start)
+
+	// Must have returned from the OS deadlines/teardown bounds, not by waiting out the stall.
+	if elapsed >= stallRelease-5*time.Second {
+		t.Fatalf("rows iteration/close took %s — it appears to have waited for the stall release (%s); a teardown read is not bounded", elapsed, stallRelease)
+	}
+	// The cancelled fetch must surface an error, not a silent success.
+	if iterErr == nil {
+		t.Fatal("expected a context-deadline error from the cancelled fetch, got nil")
+	}
+
+	proxy.release() // also covered by defers; lets a fresh connection be established now
+
+	// The desynced connection must have been evicted, not pooled. A fresh query on the
+	// same *sql.DB must succeed — no leftover-bytes "Error op_response:1".
+	pctx, pcancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer pcancel()
+	var probe int
+	if err := db.QueryRowContext(pctx, "SELECT 6809 FROM rdb$database").Scan(&probe); err != nil {
+		t.Fatalf("reuse query after cancellation failed (poisoned conn returned to pool): %v", err)
+	}
+	if probe != 6809 {
+		t.Fatalf("reuse query returned %d, want 6809 (conn returned misaligned data)", probe)
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -29,7 +29,6 @@ import (
 	"io"
 	"reflect"
 	"strings"
-	"time"
 )
 
 type firebirdsqlRows struct {
@@ -40,6 +39,7 @@ type firebirdsqlRows struct {
 	moreData         bool
 	result           []driver.Value
 	closeStmtOnClose bool // true for internal stmts that should be dropped on rows.Close()
+	badConn          bool // set when a fetch was abandoned under an expired ctx (wire desynced)
 }
 
 func newFirebirdsqlRows(ctx context.Context, stmt *firebirdsqlStmt, result []driver.Value) *firebirdsqlRows {
@@ -66,24 +66,33 @@ func (rows *firebirdsqlRows) Columns() []string {
 }
 
 func (rows *firebirdsqlRows) Close() error {
+	var err error
 	if rows.closeStmtOnClose {
-		return rows.stmt.Close()
+		err = rows.stmt.Close()
+	} else {
+		err = rows.stmt.closeCursor()
 	}
-	return rows.stmt.closeCursor()
+	// database/sql drives connection eviction off *this* return value (Rows.close passes
+	// rowsi.Close()'s result to releaseConn -> putConn), not off Next's error. So when a fetch
+	// was abandoned mid-stream under an expired context the wire is desynced — return
+	// ErrBadConn here so the poisoned conn is evicted, not pooled (otherwise the next query
+	// reads leftover fetch bytes where it expects op_response -> "Error op_response:N").
+	if rows.badConn {
+		return driver.ErrBadConn
+	}
+	return err
 }
 
 func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
-	if rows.ctx.Err() != nil {
+	// contextErrOrDeadlineExceeded folds in the timer-starvation fallback: it returns the
+	// context error, or DeadlineExceeded when the wall clock has passed ctx.Deadline() even
+	// though ctx.Err() is still nil (Go's sysmon delayed by a CPU-bound Firebird query). We
+	// fire op_cancel, so the wire state is then uncertain — mark the conn bad so Close() evicts
+	// it (the eviction lever; see Close). The caller still sees the clean context error.
+	if cerr := contextErrOrDeadlineExceeded(rows.ctx); cerr != nil {
 		rows.stmt.fc.wp.opCancel(fb_cancel_raise)
-		return rows.ctx.Err()
-	}
-	// Fallback for timer-starved environments: check the wall clock directly
-	// against the context deadline. This catches the case where Go's sysmon
-	// is delayed by a CPU-bound Firebird query and ctx.Err() is still nil
-	// even though the deadline has passed.
-	if dl, ok := rows.ctx.Deadline(); ok && time.Now().After(dl) {
-		rows.stmt.fc.wp.opCancel(fb_cancel_raise)
-		return context.DeadlineExceeded
+		rows.badConn = true
+		return cerr
 	}
 
 	if rows.stmt.stmtType == isc_info_sql_stmt_exec_procedure {
@@ -129,7 +138,13 @@ func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
 		}
 
 		if err != nil {
-			if cerr := rows.ctx.Err(); cerr != nil {
+			// A ctx-deadline abandon (incl. the OS-deadline fallback firing while
+			// ctx.Err() is still nil) leaves the fetch response bytes pending on the
+			// wire — the conn is desynced. Mark it bad so Close() evicts it rather than
+			// pooling a conn the next query would read misaligned ("Error op_response:N").
+			// A genuine server/wire error keeps the wire synced, so it stays reusable.
+			if cerr := contextErrOrDeadlineExceeded(rows.ctx); cerr != nil {
+				rows.badConn = true // fetch abandoned mid-stream: wire desynced
 				return cerr
 			}
 			return

--- a/statement.go
+++ b/statement.go
@@ -199,6 +199,10 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 		return e
 	})
 
+	// Deadline-abandon disposition: drain the cancel ack if the OS deadline fired, then evict
+	// (ErrBadConn) if the ctx deadline has passed. This block is repeated verbatim at the other
+	// three blocking-read sites (exec's opInfoSql read; query's exec_procedure and select reads) —
+	// keep all four in sync.
 	if err != nil {
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			// OS deadline fired (sysmon was starved). The read was cleanly

--- a/statement.go
+++ b/statement.go
@@ -222,6 +222,15 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 
 	_, _, buf, err := stmt.fc.wp.opResponse()
 	if err != nil {
+		// Mirror the 1st-read defense (above): this opInfoSql records read is bounded by the
+		// still-armed enforceDeadline, so it cannot hang, but on a ctx-deadline abandon the
+		// wire is desynced — cancel/drain and evict rather than pool the poisoned conn.
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			err = stmt.cancelAndDrain()
+		}
+		if contextErrOrDeadlineExceeded(ctx) != nil {
+			return result, fmt.Errorf("%w: %w", err, driver.ErrBadConn)
+		}
 		return
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -50,7 +50,9 @@ func (stmt *firebirdsqlStmt) freeStatement(mode int32) error {
 	if (stmt.fc.wp.acceptType & ptype_MASK) == ptype_lazy_send {
 		stmt.fc.wp.lazyResponseCount++
 	} else {
-		_, _, _, err = stmt.fc.wp.opResponse()
+		// Teardown read: bound it so a silent wire can't hang rows.Close()/stmt.Close()
+		// (reached automatically by database/sql's awaitDone on a mid-fetch ctx deadline).
+		_, _, _, err = stmt.fc.wp.opResponseTimeout(abandonReadTimeout)
 	}
 	if stmt.fc.tx.isAutocommit {
 		stmt.fc.tx.commitRetainging()
@@ -144,11 +146,9 @@ func (stmt *firebirdsqlStmt) enforceDeadline(ctx context.Context) func() {
 // It resets the connection deadline, sends op_cancel so the server cleans up,
 // reads the resulting error response, and returns it.
 func (stmt *firebirdsqlStmt) cancelAndDrain() error {
-	stmt.fc.wp.conn.SetDeadline(time.Time{}) // re-enable I/O
+	stmt.fc.wp.conn.SetDeadline(time.Time{}) // re-enable I/O before the op_cancel write
 	stmt.fc.wp.opCancel(fb_cancel_raise)
-	stmt.fc.wp.conn.SetDeadline(time.Now().Add(10 * time.Second))
-	_, _, _, err := stmt.fc.wp.opResponse()
-	stmt.fc.wp.conn.SetDeadline(time.Time{})
+	_, _, _, err := stmt.fc.wp.opResponseTimeout(abandonReadTimeout)
 	return err
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -115,7 +115,9 @@ func (tx *firebirdsqlTx) commitRetainging() (err error) {
 	if err != nil {
 		return
 	}
-	_, _, _, err = tx.fc.wp.opResponse()
+	// Teardown read: bounded so the autocommit commit-retaining cannot hang a silent-wire
+	// close (it runs in freeStatement's teardown path as well as the exec hot path).
+	_, _, _, err = tx.fc.wp.opResponseTimeout(abandonReadTimeout)
 	tx.isAutocommit = tx.fc.isAutocommit
 	return
 }
@@ -136,7 +138,9 @@ func (tx *firebirdsqlTx) Rollback() (err error) {
 	if err != nil {
 		return err
 	}
-	_, _, _, err = tx.fc.wp.opResponse()
+	// Teardown read: bounded so connection.Close()'s rollback loop cannot hang on a silent
+	// wire before it ever reaches opDetach.
+	_, _, _, err = tx.fc.wp.opResponseTimeout(abandonReadTimeout)
 	tx.isAutocommit = tx.fc.isAutocommit
 	tx.needBegin = true
 	return

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -1509,6 +1509,24 @@ func (p *wireProtocol) opResponse() (int32, []byte, []byte, error) {
 	return p._parse_op_response()
 }
 
+// abandonReadTimeout bounds a blocking op_response read on a connection that is being
+// abandoned (cancel-ack drain or teardown). See opResponseTimeout. It is a var (not a const)
+// only so tests can shorten it; production code never reassigns it.
+var abandonReadTimeout = 10 * time.Second
+
+// opResponseTimeout reads an op_response bounded by a fixed OS-level deadline (relative to
+// now, no context). It is used where the connection is effectively being abandoned and a
+// silent wire must not hang the caller: cancelAndDrain's cancel-ack read, and the teardown
+// reads (statement/cursor close, autocommit commit-retaining, rollback, detach) that
+// database/sql's awaitDone goroutine can reach automatically when a QueryContext deadline
+// fires mid-fetch. The deadline is cleared on return regardless; on timeout the caller
+// discards the connection rather than reusing it.
+func (p *wireProtocol) opResponseTimeout(d time.Duration) (int32, []byte, []byte, error) {
+	p.conn.SetDeadline(time.Now().Add(d))
+	defer p.conn.SetDeadline(time.Time{})
+	return p.opResponse()
+}
+
 func (p *wireProtocol) opSqlResponse(xsqlda []xSQLVAR) ([]driver.Value, error) {
 	p.debugPrint("opSqlResponse")
 	b, err := p.recvPackets(4)


### PR DESCRIPTION
this mr fixes the fetch and teardown paths, mirroring the recent exec-path fix (6f05210).

## PROBLEM
when a `QueryContext` deadline fires mid-fetch on an unresponsive wire, two things can go wrong: the query timeout hangs anyway, and a desynced connection poisons the pool.

## CHANGES
- bound every teardown `op_response` read with a fixed OS deadline (these reads had none before);
- the fetch path now marks the connection bad on a context abandon, so `rows.Close()` returns `driver.ErrBadConn;
- exec()'s 2nd (records-info) read now drains the cancel ack and evicts on context expiry.
