### PR TITLE
fix: bounds-check server-supplied lengths across the wire protocol layer

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"errors"
+	"io"
 	"slices"
 	"testing"
 )
@@ -14,22 +15,25 @@ import (
 // Unit tests — no live Firebird server required
 // ---------------------------------------------------------------------------
 
-// testProtocol returns a wireProtocol whose reader is backed by the provided bytes.
+// testProtocol returns a wireProtocol whose reader is backed by the provided
+// bytes. Writes are discarded, so request/response round trips can be tested
+// by laying out the expected responses back to back in data.
 func testProtocol(data []byte) *wireProtocol {
 	p := &wireProtocol{}
 	p.conn.reader = bufio.NewReader(bytes.NewReader(data))
+	p.conn.writer = bufio.NewWriter(io.Discard)
 	return p
 }
 
 // statusBuf is a helper to build synthetic Firebird status-vector byte sequences.
 type statusBuf struct{ buf bytes.Buffer }
 
-func (s *statusBuf) tag(t int32)  { s.int32(t) }
-func (s *statusBuf) end()         { s.tag(isc_arg_end) }
+func (s *statusBuf) tag(t int32) { s.int32(t) }
+func (s *statusBuf) end()        { s.tag(isc_arg_end) }
 func (s *statusBuf) int32(v int32) {
 	_ = binary.Write(&s.buf, binary.BigEndian, v)
 }
-func (s *statusBuf) gds(code int) { s.tag(isc_arg_gds); s.int32(int32(code)) }
+func (s *statusBuf) gds(code int)     { s.tag(isc_arg_gds); s.int32(int32(code)) }
 func (s *statusBuf) warning(code int) { s.tag(isc_arg_warning); s.int32(int32(code)) }
 func (s *statusBuf) str(v string) {
 	s.tag(isc_arg_string)
@@ -99,9 +103,9 @@ func TestParseStatusVector_MultiChain(t *testing.T) {
 	var sb statusBuf
 	// Two chained GDS codes, each with their own params — verifies per-code Params alignment
 	sb.gds(335544665) // code A
-	sb.str("CON_A")  // @1 for A
+	sb.str("CON_A")   // @1 for A
 	sb.gds(335544349) // code B (follow-up detail)
-	sb.str("val=X")  // @1 for B
+	sb.str("val=X")   // @1 for B
 	sb.end()
 
 	sv, err := testProtocol(sb.bytes())._parse_status_vector()

--- a/eventmanager.go
+++ b/eventmanager.go
@@ -26,6 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package firebirdsql
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -60,15 +61,45 @@ func (e *eventManager) wait(event *remoteEvent, eventCounts chan<- Event) <-chan
 			op := bytes_to_bint32(data)
 			switch op {
 			case op_event:
-				e.wp.recvPackets(4) //handle
-				b, _ := e.wp.recvPackets(4)
+				if _, err = e.wp.recvPackets(4); err != nil { //handle
+					chErr <- err
+					return
+				}
+				b, err := e.wp.recvPackets(4)
+				if err != nil {
+					chErr <- err
+					return
+				}
 				szBuf := bytes_to_bint32(b)
-				buffer, _ := e.wp.recvPacketsAlignment(int(szBuf))
-				e.wp.recvPackets(8) //ast
-				b, _ = e.wp.recvPackets(4)
+				// The event buffer mirrors the client's own EPB, capped at maxEpbLength;
+				// a size outside that range is malformed and must not reach make().
+				if szBuf < 0 || int(szBuf) > maxEpbLength {
+					chErr <- fmt.Errorf("firebirdsql: event buffer size %d out of range", szBuf)
+					return
+				}
+				buffer, err := e.wp.recvPacketsAlignment(int(szBuf))
+				if err != nil {
+					chErr <- err
+					return
+				}
+				if _, err = e.wp.recvPackets(8); err != nil { //ast
+					chErr <- err
+					return
+				}
+				b, err = e.wp.recvPackets(4)
+				if err != nil {
+					chErr <- err
+					return
+				}
 				eventId := bytes_to_bint32(b)
 				e.wp.debugPrint("op_event:%v: event id: %v", buffer, eventId)
-				for _, count := range event.getEventCounts(buffer) {
+				counts, err := event.getEventCounts(buffer)
+				if err != nil {
+					e.wp.debugPrint("getEventCounts:%v", err)
+					chErr <- err
+					return
+				}
+				for _, count := range counts {
 					eventCounts <- count
 				}
 			default:

--- a/firebird_version.go
+++ b/firebird_version.go
@@ -41,8 +41,14 @@ type FirebirdVersion struct {
 	Raw         string
 }
 
+// ParseFirebirdVersion parses a server version banner. An unrecognized banner
+// returns a zero-value FirebirdVersion with only Raw set (so EqualOrGreater is
+// conservatively false) instead of panicking on the nil regex match.
 func ParseFirebirdVersion(rawVersionString string) FirebirdVersion {
 	res := FirebirdVersionPattern.FindStringSubmatch(rawVersionString)
+	if res == nil {
+		return FirebirdVersion{Raw: rawVersionString}
+	}
 	major, _ := strconv.Atoi(res[4])
 	minor, _ := strconv.Atoi(res[5])
 	patch, _ := strconv.Atoi(res[6])

--- a/firebird_version_test.go
+++ b/firebird_version_test.go
@@ -1,0 +1,79 @@
+package firebirdsql
+
+import (
+	"strings"
+	"testing"
+)
+
+// serverVersionFrame builds the op_response GetServerVersion reads: a service
+// buffer of [isc_info_svc_server_version][2-byte len][banner].
+func serverVersionFrame(banner string) []byte {
+	var f acceptFrame
+	buf := []byte{isc_info_svc_server_version, byte(len(banner)), byte(len(banner) >> 8)}
+	buf = append(buf, banner...)
+	f.opResponseFrame(0, buf)
+	return f.bytes()
+}
+
+func TestGetServerVersion_Garbage(t *testing.T) {
+	svc := &ServiceManager{wp: testProtocol(serverVersionFrame("totally bogus banner"))}
+	_, err := svc.GetServerVersion()
+	if err == nil {
+		t.Fatal("expected error for unrecognized banner, got nil")
+	}
+	if !strings.Contains(err.Error(), "unrecognized server version") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetServerVersion_Valid(t *testing.T) {
+	svc := &ServiceManager{wp: testProtocol(serverVersionFrame("LI-V3.0.11.33703 Firebird 3.0"))}
+	v, err := svc.GetServerVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Major != 3 || v.Minor != 0 {
+		t.Errorf("got %d.%d, want 3.0", v.Major, v.Minor)
+	}
+}
+
+func TestParseFirebirdVersion_RealBanners(t *testing.T) {
+	cases := []struct {
+		raw                       string
+		major, minor, patch, bnum int
+	}{
+		{"LI-V2.5.9.27139 Firebird 2.5", 2, 5, 9, 27139},
+		{"LI-V3.0.11.33703 Firebird 3.0", 3, 0, 11, 33703},
+		{"WI-V5.0.1.1469 Firebird 5.0", 5, 0, 1, 1469},
+		{"LI-T6.0.0.345 Firebird 6.0 Initial", 6, 0, 0, 345},
+	}
+	for _, tt := range cases {
+		t.Run(tt.raw, func(t *testing.T) {
+			v := ParseFirebirdVersion(tt.raw)
+			if v.Major != tt.major || v.Minor != tt.minor || v.Patch != tt.patch || v.BuildNumber != tt.bnum {
+				t.Errorf("got %d.%d.%d.%d, want %d.%d.%d.%d",
+					v.Major, v.Minor, v.Patch, v.BuildNumber, tt.major, tt.minor, tt.patch, tt.bnum)
+			}
+			if v.Full == "" {
+				t.Error("Full should be populated for a real banner")
+			}
+		})
+	}
+}
+
+func TestParseFirebirdVersion_Garbage(t *testing.T) {
+	// A non-matching banner must not panic; it yields a zero version with Raw
+	// preserved and a conservatively-false EqualOrGreater.
+	for _, raw := range []string{"", "not a version", "garbage from a hostile server"} {
+		v := ParseFirebirdVersion(raw)
+		if v.Full != "" || v.Major != 0 {
+			t.Errorf("%q: expected zero version, got %+v", raw, v)
+		}
+		if v.Raw != raw {
+			t.Errorf("%q: Raw not preserved, got %q", raw, v.Raw)
+		}
+		if v.EqualOrGreater(3, 0) {
+			t.Errorf("%q: zero version must not satisfy EqualOrGreater(3,0)", raw)
+		}
+	}
+}

--- a/maintenance_manager.go
+++ b/maintenance_manager.go
@@ -199,50 +199,57 @@ func (mm *MaintenanceManager) GetLimboTransactions(database string) ([]int64, er
 		done <- true
 	}()
 
+	// Accumulate the whole stream before parsing; a record may straddle a
+	// chunk boundary (see GetUsers).
+	var acc []byte
 	for cont {
 		select {
 		case buf = <-resChan:
-			srb := NewXPBReader(buf)
-			var (
-				have bool
-				val  byte
-			)
-			for {
-				if have, val = srb.Next(); !have {
-					break
-				}
-				switch val {
-				case isc_spb_single_tra_id:
-					fallthrough
-				case isc_spb_multi_tra_id:
-					tids = append(tids, int64(srb.GetInt32()))
-				case isc_spb_single_tra_id_64:
-					fallthrough
-				case isc_spb_multi_tra_id_64:
-					tids = append(tids, srb.GetInt64())
-				case isc_spb_tra_id:
-					srb.Skip(4)
-				case isc_spb_tra_id_64:
-					srb.Skip(8)
-				case isc_spb_tra_state:
-					fallthrough
-				case isc_spb_tra_advise:
-					srb.Skip(1)
-				case isc_spb_tra_host_site:
-					fallthrough
-				case isc_spb_tra_remote_site:
-					fallthrough
-				case isc_spb_tra_db_path:
-					srb.GetString()
-				}
-			}
+			acc = append(acc, buf...)
 		case <-done:
 			cont = false
-			break
 		}
 	}
+	if err != nil {
+		return nil, err
+	}
 
-	return tids, err
+	srb := NewXPBReader(acc)
+	for {
+		have, val := srb.Next()
+		if !have {
+			break
+		}
+		switch val {
+		case isc_spb_single_tra_id:
+			fallthrough
+		case isc_spb_multi_tra_id:
+			tids = append(tids, int64(srb.GetInt32()))
+		case isc_spb_single_tra_id_64:
+			fallthrough
+		case isc_spb_multi_tra_id_64:
+			tids = append(tids, srb.GetInt64())
+		case isc_spb_tra_id:
+			srb.Skip(4)
+		case isc_spb_tra_id_64:
+			srb.Skip(8)
+		case isc_spb_tra_state:
+			fallthrough
+		case isc_spb_tra_advise:
+			srb.Skip(1)
+		case isc_spb_tra_host_site:
+			fallthrough
+		case isc_spb_tra_remote_site:
+			fallthrough
+		case isc_spb_tra_db_path:
+			srb.GetString()
+		}
+	}
+	if err := srb.Err(); err != nil {
+		return nil, err
+	}
+
+	return tids, nil
 }
 
 func (mm *MaintenanceManager) CommitTransaction(database string, transaction int64) error {

--- a/remoteEvent.go
+++ b/remoteEvent.go
@@ -28,6 +28,7 @@ package firebirdsql
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -100,26 +101,43 @@ func (e *remoteEvent) cancelEvents() {
 	atomic.StoreInt32(&e.running, 0)
 }
 
-func (e *remoteEvent) getEventCounts(data []byte) []Event {
-	e.mu.Lock()
-	e.prevCounts = make(map[string]int, len(e.events))
-	for k, v := range e.counts {
-		e.prevCounts[k] = v
-		e.counts[k] = 0
+func (e *remoteEvent) getEventCounts(data []byte) ([]Event, error) {
+	// data is the server's event buffer: a version byte, then repeated
+	// <name-length byte><name><4-byte count> records. Offsets are driven by
+	// the name-length byte, so each is bounds-checked before slicing.
+	if len(data) == 0 || data[0] != byte(EPB_version1) {
+		return nil, fmt.Errorf("firebirdsql: malformed event buffer (bad or missing version byte)")
 	}
 
-	for i := 1; i < len(data); {
-		length := int(data[i])
-		i++
-		eventName := string(data[i : i+length])
-		i += length
-		_, found := e.counts[eventName]
-		if found {
-			e.counts[eventName] = int(bytes_to_int32(data[i:]) - 1)
+	if err := func() error {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		e.prevCounts = make(map[string]int, len(e.events))
+		for k, v := range e.counts {
+			e.prevCounts[k] = v
+			e.counts[k] = 0
 		}
-		i += 4
+
+		for i := 1; i < len(data); {
+			length := int(data[i])
+			i++
+			if i+length > len(data) {
+				return fmt.Errorf("firebirdsql: event name length %d exceeds buffer", length)
+			}
+			eventName := string(data[i : i+length])
+			i += length
+			if i+4 > len(data) {
+				return fmt.Errorf("firebirdsql: event count truncated for %q", eventName)
+			}
+			if _, found := e.counts[eventName]; found {
+				e.counts[eventName] = int(bytes_to_int32(data[i:]) - 1)
+			}
+			i += 4
+		}
+		return nil
+	}(); err != nil {
+		return nil, err
 	}
-	e.mu.Unlock()
 
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -136,7 +154,7 @@ func (e *remoteEvent) getEventCounts(data []byte) []Event {
 			RemoteID: atomic.LoadInt32(&e.rid),
 		})
 	}
-	return result
+	return result, nil
 }
 
 func buildEpbSlice(events []string, counts map[string]int) []byte {

--- a/remoteevent_test.go
+++ b/remoteevent_test.go
@@ -1,0 +1,97 @@
+//go:build !plan9
+
+package firebirdsql
+
+import (
+	"strings"
+	"testing"
+)
+
+// eventBuffer builds an op_event payload: a version byte followed by repeated
+// <name-length><name><4-byte little-endian count> records.
+func eventBuffer(version byte, entries ...struct {
+	name  string
+	count int32
+}) []byte {
+	buf := []byte{version}
+	for _, e := range entries {
+		buf = append(buf, byte(len(e.name)))
+		buf = append(buf, e.name...)
+		buf = append(buf, byte(e.count), byte(e.count>>8), byte(e.count>>16), byte(e.count>>24))
+	}
+	return buf
+}
+
+func TestEventManagerWait_OversizedBuffer(t *testing.T) {
+	var f acceptFrame
+	f.int32(op_event)
+	f.int32(7)                // event handle
+	f.int32(maxEpbLength + 1) // claimed event-buffer size: out of range
+
+	em := &eventManager{wp: testProtocol(f.bytes())}
+	chErr := em.wait(newRemoteEvent(), make(chan Event, 1))
+	err := <-chErr
+	if err == nil {
+		t.Fatal("expected error for oversized event buffer, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestEventManagerWait_TruncatedRead(t *testing.T) {
+	var f acceptFrame
+	f.int32(op_event)
+	f.int32(7) // handle, then the stream ends before the size word
+
+	em := &eventManager{wp: testProtocol(f.bytes())}
+	chErr := em.wait(newRemoteEvent(), make(chan Event, 1))
+	if err := <-chErr; err == nil {
+		t.Fatal("expected error for truncated event frame, got nil")
+	}
+}
+
+func TestGetEventCounts_Valid(t *testing.T) {
+	e := newRemoteEvent()
+	if err := e.queueEvents("evt"); err != nil {
+		t.Fatal(err)
+	}
+	data := eventBuffer(byte(EPB_version1), struct {
+		name  string
+		count int32
+	}{"evt", 5})
+
+	events, err := e.getEventCounts(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 1 || events[0].Name != "evt" || events[0].Count != 4 {
+		t.Errorf("events: got %+v, want one evt with count 4", events)
+	}
+}
+
+func TestGetEventCounts_Malformed(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    []byte
+		wantSub string
+	}{
+		{"empty", nil, "version byte"},
+		{"bad version", []byte{9, 3, 'e', 'v', 't'}, "version byte"},
+		{"name past end", []byte{byte(EPB_version1), 50, 'e', 'v', 't'}, "name length"},
+		{"count truncated", []byte{byte(EPB_version1), 3, 'e', 'v', 't', 0, 0}, "count truncated"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newRemoteEvent()
+			_ = e.queueEvents("evt")
+			_, err := e.getEventCounts(tt.data)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -26,6 +26,7 @@ package firebirdsql
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"reflect"
 	"strings"
@@ -147,6 +148,14 @@ func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
 				rows.badConn = true // fetch abandoned mid-stream: wire desynced
 				return cerr
 			}
+			// The fetch decode (readRow, opFetchResponse, getBlobSegments) tags a
+			// malformed-length/count error with driver.ErrBadConn because it aborts
+			// mid-stream with bytes left on the wire. Close() evicts off rows.badConn,
+			// not this return value, so propagate the signal here or the desynced conn
+			// gets pooled.
+			if errors.Is(err, driver.ErrBadConn) {
+				rows.badConn = true
+			}
 			return
 		}
 		rows.currentChunkIdx = 0
@@ -163,6 +172,11 @@ func (rows *firebirdsqlRows) Next(dest []driver.Value) (err error) {
 			var blob []byte
 			blob, err = rows.stmt.fc.wp.getBlobSegments(blobId, rows.stmt.fc.tx.transHandle)
 			if err != nil {
+				// Same as the fetch branch above: getBlobSegments tags its error with
+				// driver.ErrBadConn, and Close() only evicts when rows.badConn is set here.
+				if errors.Is(err, driver.ErrBadConn) {
+					rows.badConn = true
+				}
 				return
 			}
 			if rows.stmt.resultXsqlda[i].sqlsubtype == 1 {

--- a/service_manager.go
+++ b/service_manager.go
@@ -345,7 +345,11 @@ func (svc *ServiceManager) WaitBuffer(stream chan []byte) error {
 		}
 		switch buf[0] {
 		case isc_info_svc_to_eof:
-			dataLen := bytes_to_int16(buf[1:3])
+			if len(buf) < 4 {
+				return fmt.Errorf("firebirdsql: service stream chunk too short (%d bytes)", len(buf))
+			}
+			// dataLen is a USHORT; read it unsigned so a chunk over 32 KiB can't go negative.
+			dataLen := int(bytes_to_uint16(buf[1:3]))
 			if dataLen == 0 {
 				if buf[3] == isc_info_svc_timeout {
 					break
@@ -356,8 +360,15 @@ func (svc *ServiceManager) WaitBuffer(stream chan []byte) error {
 					break
 				}
 			}
+			if 3+dataLen > len(buf) {
+				return fmt.Errorf("firebirdsql: service stream chunk length %d exceeds buffer (%d bytes)", dataLen, len(buf))
+			}
 			stream <- buf[3 : 3+dataLen]
 		case isc_info_truncated:
+			// Bound the growth: endless isc_info_truncated would overflow bufferLength negative.
+			if bufferLength >= maxWirePayload {
+				return fmt.Errorf("firebirdsql: service response exceeds %d bytes", maxWirePayload)
+			}
 			bufferLength *= 2
 		case isc_info_end:
 			cont = false
@@ -406,11 +417,16 @@ func (svc *ServiceManager) GetString() (result string, end bool, err error) {
 	if buf, err = svc.GetServiceInfo(GetServiceInfoSPBPreamble(), []byte{isc_info_svc_line}, -1); err != nil {
 		return "", false, err
 	}
-	if bytes.Compare(buf[:4], []byte{isc_info_svc_line, 0, 0, isc_info_end}) == 0 {
+	if len(buf) < 4 {
+		return "", false, fmt.Errorf("firebirdsql: service line response too short (%d bytes)", len(buf))
+	}
+	if bytes.Equal(buf[:4], []byte{isc_info_svc_line, 0, 0, isc_info_end}) {
 		return "", true, nil
 	}
 
-	return NewXPBReader(buf[1:]).GetString(), false, nil
+	rdr := NewXPBReader(buf[1:])
+	result = rdr.GetString()
+	return result, false, rdr.Err()
 }
 
 func (svc *ServiceManager) GetServiceInfo(spb []byte, srb []byte, bufferLength int32) ([]byte, error) {
@@ -442,7 +458,8 @@ func (svc *ServiceManager) GetServiceInfoInt(item byte) (int16, error) {
 	if buf, err = svc.GetServiceInfo(GetServiceInfoSPBPreamble(), []byte{item}, BUFFER_LEN); err != nil {
 		return 0, err
 	}
-	return NewXPBReader(buf[1:]).GetInt16(), nil
+	rdr := NewXPBReader(buf[1:])
+	return rdr.GetInt16(), rdr.Err()
 }
 
 func (svc *ServiceManager) GetServiceInfoString(item byte) (string, error) {
@@ -451,7 +468,8 @@ func (svc *ServiceManager) GetServiceInfoString(item byte) (string, error) {
 	if buf, err = svc.GetServiceInfo(GetServiceInfoSPBPreamble(), []byte{item}, -1); err != nil {
 		return "", err
 	}
-	return NewXPBReader(buf[1:]).GetString(), nil
+	rdr := NewXPBReader(buf[1:])
+	return rdr.GetString(), rdr.Err()
 }
 
 func (svc *ServiceManager) GetServerVersionString() (string, error) {
@@ -459,11 +477,17 @@ func (svc *ServiceManager) GetServerVersionString() (string, error) {
 }
 
 func (svc *ServiceManager) GetServerVersion() (FirebirdVersion, error) {
-	if ver, err := svc.GetServerVersionString(); err == nil {
-		return ParseFirebirdVersion(ver), nil
-	} else {
+	ver, err := svc.GetServerVersionString()
+	if err != nil {
 		return FirebirdVersion{}, err
 	}
+	parsed := ParseFirebirdVersion(ver)
+	if parsed.Full == "" {
+		// Turn an unrecognized banner into an error rather than silently returning a
+		// zero version (see ParseFirebirdVersion) that would flip feature gates off.
+		return parsed, fmt.Errorf("firebirdsql: unrecognized server version banner %q", ver)
+	}
+	return parsed, nil
 }
 
 func (svc *ServiceManager) GetArchitecture() (string, error) {
@@ -509,6 +533,9 @@ func (svc *ServiceManager) GetSvrDbInfo() (*SrvDbInfo, error) {
 		case isc_spb_dbname:
 			databases = append(databases, srb.GetString())
 		}
+	}
+	if err := srb.Err(); err != nil {
+		return &SrvDbInfo{}, err
 	}
 
 	return &SrvDbInfo{int(attachmentsCount), int(databasesCount), databases}, nil

--- a/srp.go
+++ b/srp.go
@@ -30,7 +30,6 @@ import (
 	"crypto/sha256"
 	"hash"
 	"math/big"
-
 )
 
 const (
@@ -57,9 +56,10 @@ func pad(v *big.Int) []byte {
 		buf[i], buf[j] = buf[j], buf[i]
 	}
 
-	// skip 0
+	// skip leading zero bytes; bound the scan so an all-zero value (e.g. a
+	// zero server public key) yields an empty slice instead of overrunning buf.
 	var i int
-	for i = 0; buf[i] == 0; i++ {
+	for i = 0; i < len(buf) && buf[i] == 0; i++ {
 	}
 	return buf[i:]
 }
@@ -160,7 +160,7 @@ func getServerSeed(v *big.Int) (keyB *big.Int, keyb *big.Int, err error) {
 		return
 	}
 	keyb = new(big.Int).SetBytes(b)
-	gb := new(big.Int).Exp(g, keyb, prime)              // gb = pow(g, b, N)
+	gb := new(big.Int).Exp(g, keyb, prime)                   // gb = pow(g, b, N)
 	kv := new(big.Int).Mod(new(big.Int).Mul(k, v), prime)    // kv = (k * v) % N
 	keyB = new(big.Int).Mod(new(big.Int).Add(kv, gb), prime) // B = (kv + gb) % N
 	return
@@ -170,12 +170,12 @@ func getClientSession(user string, password string, salt []byte, keyA *big.Int, 
 	prime, g, k := getPrime()
 	u := getScramble(keyA, keyB)
 	x := getUserHash(salt, user, password)
-	gx := new(big.Int).Exp(g, x, prime)                     // gx = pow(g, x, N)
+	gx := new(big.Int).Exp(g, x, prime)                          // gx = pow(g, x, N)
 	kgx := new(big.Int).Mod(new(big.Int).Mul(k, gx), prime)      // kgx = (k * gx) % N
 	diff := new(big.Int).Mod(new(big.Int).Sub(keyB, kgx), prime) // diff = (B - kgx) % N
 	ux := new(big.Int).Mod(new(big.Int).Mul(u, x), prime)        // ux = (u * x) % N
 	aux := new(big.Int).Mod(new(big.Int).Add(keya, ux), prime)   // aux = (a + ux) % N
-	sessionSecret := new(big.Int).Exp(diff, aux, prime)     // (B - kg^x) ^ (a + ux)
+	sessionSecret := new(big.Int).Exp(diff, aux, prime)          // (B - kg^x) ^ (a + ux)
 
 	return bigIntToSha1(sessionSecret)
 }

--- a/srp_test.go
+++ b/srp_test.go
@@ -24,8 +24,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package firebirdsql
 
 import (
+	"math/big"
 	"testing"
 )
+
+func TestPad(t *testing.T) {
+	// An all-zero value must not run the zero-skip scan past the end of the
+	// buffer; a zero public key is server-controlled input during SRP auth.
+	if got := pad(big.NewInt(0)); len(got) != 0 {
+		t.Errorf("pad(0): got %d bytes, want empty", len(got))
+	}
+	if got := pad(big.NewInt(1)); len(got) != 1 || got[0] != 1 {
+		t.Errorf("pad(1): got %v, want [1]", got)
+	}
+}
 
 func TestSrp(t *testing.T) {
 	user := "SYSDBA"

--- a/subscriber.go
+++ b/subscriber.go
@@ -167,14 +167,25 @@ func (s *Subscription) connAuxRequest() (int32, string, error) {
 	if err != nil {
 		return -1, "", err
 	}
+	// buf is the server's address response and may be empty; each branch
+	// bounds-checks the bytes it reads before slicing.
+	if len(buf) < 4 {
+		return -1, "", fmt.Errorf("firebirdsql: aux connection response too short (%d bytes)", len(buf))
+	}
 	family := bytes_to_int16(buf[0:2])
 	port := binary.BigEndian.Uint16(buf[2:4])
 
 	var addr netip.Addr
 	switch family {
 	case syscall.AF_INET:
+		if len(buf) < 8 {
+			return -1, "", fmt.Errorf("firebirdsql: aux connection IPv4 address truncated (%d bytes)", len(buf))
+		}
 		addr = netip.AddrFrom4([4]byte(buf[4:8]))
 	case syscall.AF_INET6:
+		if len(buf) < 24 {
+			return -1, "", fmt.Errorf("firebirdsql: aux connection IPv6 address truncated (%d bytes)", len(buf))
+		}
 		if reflect.DeepEqual(buf[4:20], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}) {
 			addr = netip.AddrFrom4([4]byte(buf[20:24]))
 		} else {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -1,0 +1,70 @@
+//go:build !plan9
+
+package firebirdsql
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// auxResponseFrame builds the op_response packet connAuxRequest reads, carrying
+// addrPayload as the length-prefixed data buffer.
+func auxResponseFrame(addrPayload []byte) []byte {
+	var f acceptFrame
+	f.opResponseFrame(5, addrPayload) // aux handle 5
+	return f.bytes()
+}
+
+func newTestSubscription(frame []byte) *Subscription {
+	return &Subscription{fc: &firebirdsqlConn{wp: testProtocol(frame)}}
+}
+
+func sockAddrIPv4(port int, a, b, c, d byte) []byte {
+	return []byte{
+		byte(syscall.AF_INET & 0xFF), byte(syscall.AF_INET >> 8),
+		byte(port >> 8), byte(port & 0xFF), // port, big-endian
+		a, b, c, d, // address
+		0, 0, 0, 0, 0, 0, 0, 0, // sockaddr_in padding
+	}
+}
+
+func TestConnAuxRequest_ValidIPv4(t *testing.T) {
+	s := newTestSubscription(auxResponseFrame(sockAddrIPv4(3051, 192, 168, 1, 5)))
+	handle, addr, err := s.connAuxRequest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handle != 5 {
+		t.Errorf("handle: got %d, want 5", handle)
+	}
+	if addr != "192.168.1.5:3051" {
+		t.Errorf("addr: got %q, want 192.168.1.5:3051", addr)
+	}
+}
+
+func TestConnAuxRequest_TruncatedBuffers(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		wantSub string
+	}{
+		{"empty", nil, "too short"},
+		{"header only", []byte{2, 0, 0x0B, 0xEB}, "IPv4 address truncated"},
+		{"ipv6 truncated", append([]byte{
+			byte(syscall.AF_INET6 & 0xFF), byte(syscall.AF_INET6 >> 8), 0x0B, 0xEB,
+		}, make([]byte, 8)...), "IPv6 address truncated"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestSubscription(auxResponseFrame(tt.payload))
+			_, _, err := s.connAuxRequest()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/user_manager.go
+++ b/user_manager.go
@@ -23,6 +23,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package firebirdsql
 
+import "fmt"
+
 type User struct {
 	Username   *string
 	Password   *string
@@ -242,53 +244,67 @@ func (um *UserManager) GetUsers() ([]User, error) {
 		done <- true
 	}()
 
+	// Accumulate the whole service stream before parsing: the server splits
+	// records at arbitrary chunk boundaries, so a user record can span two chunks
+	// and per-chunk parsing would mis-read one that straddles the boundary.
+	var acc []byte
 	for cont {
 		select {
 		case buf = <-resChan:
-			srb := NewXPBReader(buf)
-			var (
-				user *User
-				have bool
-				val  byte
-			)
-			for {
-				if have, val = srb.Next(); !have {
-					break
-				}
-				switch val {
-				case isc_spb_sec_username:
-					if user != nil {
-						users = append(users, *user)
-					}
-					u := NewUser(WithUsername(srb.GetString()))
-					user = &u
-				case isc_spb_sec_firstname:
-					s := srb.GetString()
-					user.FirstName = &s
-				case isc_spb_sec_middlename:
-					s := srb.GetString()
-					user.MiddleName = &s
-				case isc_spb_sec_lastname:
-					s := srb.GetString()
-					user.LastName = &s
-				case isc_spb_sec_userid:
-					user.UserId = srb.GetInt32()
-				case isc_spb_sec_groupid:
-					user.GroupId = srb.GetInt32()
-				case isc_spb_sec_admin:
-					a := srb.GetInt32() > 0
-					user.Admin = &a
-				}
-			}
-			if user != nil {
-				users = append(users, *user)
-			}
+			acc = append(acc, buf...)
 		case <-done:
 			cont = false
 		}
 	}
+	if err != nil {
+		return nil, err
+	}
 
-	return users, err
+	srb := NewXPBReader(acc)
+	var user *User
+	for {
+		have, val := srb.Next()
+		if !have {
+			break
+		}
+		// Every non-username tag belongs to the user opened by the preceding
+		// username tag; a stream leading with a field tag would deref a nil user.
+		if val != isc_spb_sec_username && user == nil {
+			return nil, fmt.Errorf("firebirdsql: user field 0x%02x before any username", val)
+		}
+		switch val {
+		case isc_spb_sec_username:
+			if user != nil {
+				users = append(users, *user)
+			}
+			u := NewUser(WithUsername(srb.GetString()))
+			user = &u
+		case isc_spb_sec_firstname:
+			s := srb.GetString()
+			user.FirstName = &s
+		case isc_spb_sec_middlename:
+			s := srb.GetString()
+			user.MiddleName = &s
+		case isc_spb_sec_lastname:
+			s := srb.GetString()
+			user.LastName = &s
+		case isc_spb_sec_userid:
+			user.UserId = srb.GetInt32()
+		case isc_spb_sec_groupid:
+			user.GroupId = srb.GetInt32()
+		case isc_spb_sec_admin:
+			a := srb.GetInt32() > 0
+			user.Admin = &a
+		}
+	}
+	if err := srb.Err(); err != nil {
+		return nil, err
+	}
+	if user != nil {
+		users = append(users, *user)
+	}
+
+	return users, nil
 }
 
 func (um *UserManager) adminRoleMappingAction(action byte) error {

--- a/user_manager_parse_test.go
+++ b/user_manager_parse_test.go
@@ -1,0 +1,47 @@
+package firebirdsql
+
+import (
+	"strings"
+	"testing"
+)
+
+// serviceStreamFrames builds the op_response packets GetUsers reads: a
+// ServiceStart ack, one isc_info_svc_to_eof chunk carrying payload, then a
+// terminating chunk.
+func serviceStreamFrames(payload []byte) []byte {
+	var f acceptFrame
+	f.opResponseFrame(0, nil) // ServiceStart ack
+	chunk := append([]byte{isc_info_svc_to_eof, byte(len(payload)), byte(len(payload) >> 8)}, payload...)
+	f.opResponseFrame(0, chunk)
+	f.opResponseFrame(0, []byte{isc_info_svc_to_eof, 0, 0, isc_info_end})
+	return f.bytes()
+}
+
+func newTestUserManager(frame []byte) *UserManager {
+	return &UserManager{sm: &ServiceManager{wp: testProtocol(frame)}}
+}
+
+func TestGetUsers_Valid(t *testing.T) {
+	payload := []byte{isc_spb_sec_username, 6, 0, 's', 'y', 's', 'd', 'b', 'a'}
+	um := newTestUserManager(serviceStreamFrames(payload))
+	users, err := um.GetUsers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(users) != 1 || users[0].Username == nil || *users[0].Username != "sysdba" {
+		t.Fatalf("users: got %+v, want one user 'sysdba'", users)
+	}
+}
+
+func TestGetUsers_FieldBeforeUsername(t *testing.T) {
+	// A firstname tag with no preceding username must error, not nil-panic.
+	payload := []byte{isc_spb_sec_firstname, 3, 0, 'a', 'b', 'c'}
+	um := newTestUserManager(serviceStreamFrames(payload))
+	_, err := um.GetUsers()
+	if err == nil {
+		t.Fatal("expected error for field before username, got nil")
+	}
+	if !strings.Contains(err.Error(), "before any username") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -129,6 +129,10 @@ func bytes_to_int16(b []byte) int16 {
 	return int16(binary.LittleEndian.Uint16(b))
 }
 
+func bytes_to_uint16(b []byte) uint16 {
+	return binary.LittleEndian.Uint16(b)
+}
+
 func bytes_to_bint64(b []byte) int64 {
 	return int64(binary.BigEndian.Uint64(b))
 }

--- a/wireparse_fuzz_test.go
+++ b/wireparse_fuzz_test.go
@@ -1,0 +1,102 @@
+//go:build !plan9
+
+package firebirdsql
+
+import "testing"
+
+// These fuzz targets exercise the wire-parse paths that consume
+// server-supplied lengths/counts. The goal is the absence of panics: every
+// guarded parser must return an error (or a zero value) on arbitrary input,
+// never crash. CI runs the seed corpus on every `go test`.
+
+func FuzzParseStatusVector(f *testing.F) {
+	var sb statusBuf
+	sb.gds(335544665)
+	sb.str("INTEG_1")
+	sb.sqlState("23000")
+	sb.end()
+	f.Add(sb.bytes())
+	f.Add([]byte{})
+	f.Add([]byte{0, 0, 0, 4, 0xFF, 0xFF, 0xFF, 0xFF}) // isc_arg_string, negative length
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = testProtocol(data)._parse_status_vector()
+	})
+}
+
+func FuzzParseOpResponse(f *testing.F) {
+	var ok acceptFrame
+	ok.int32(1)
+	ok.buf.Write(make([]byte, 8))
+	ok.blob([]byte("hello"))
+	ok.int32(isc_arg_end)
+	f.Add(ok.bytes())
+	f.Add([]byte{})
+	f.Add([]byte{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF}) // huge buf_len
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _, _ = testProtocol(data)._parse_op_response()
+	})
+}
+
+func FuzzXPBReader(f *testing.F) {
+	f.Add([]byte{4, 0, 't', 'e', 's', 't'})
+	f.Add([]byte{})
+	f.Add([]byte{0xFF, 0xFF})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := NewXPBReader(data)
+		// Drive the operation sequence from the input itself so the fuzzer
+		// explores interactions between read kinds, not a fixed drain order.
+		for i := 0; i < len(data) && !r.End(); i++ {
+			switch data[i] % 6 {
+			case 0:
+				r.Next()
+			case 1:
+				r.GetInt16()
+			case 2:
+				r.GetInt32()
+			case 3:
+				r.GetInt64()
+			case 4:
+				r.GetString()
+			case 5:
+				r.Skip(int(data[i]))
+			}
+		}
+		_ = r.Err()
+	})
+}
+
+func FuzzGuessWireCrypt(f *testing.F) {
+	f.Add([]byte{1, 4, 'A', 'r', 'c', '4'})
+	f.Add([]byte{})
+	f.Add([]byte{3, 0xFF}) // tag with a length running past the buffer
+
+	plugins := splitList(defaultWireCryptPlugins)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		(&wireProtocol{})._guess_wire_crypt(data, plugins)
+	})
+}
+
+func FuzzParseFirebirdVersion(f *testing.F) {
+	f.Add("LI-V3.0.11.33703 Firebird 3.0")
+	f.Add("")
+	f.Add("garbage")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		ParseFirebirdVersion(s)
+	})
+}
+
+func FuzzGetEventCounts(f *testing.F) {
+	f.Add([]byte{byte(EPB_version1), 3, 'e', 'v', 't', 1, 0, 0, 0})
+	f.Add([]byte{})
+	f.Add([]byte{byte(EPB_version1), 0xFF, 'x'})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		e := newRemoteEvent()
+		_ = e.queueEvents("evt")
+		_, _ = e.getEventCounts(data)
+	})
+}

--- a/wireprotocol.go
+++ b/wireprotocol.go
@@ -46,6 +46,18 @@ const (
 	BUFFER_LEN        = 1024
 	MAX_CHAR_LENGTH   = 32767
 	BLOB_SEGMENT_SIZE = 32000
+
+	// maxWirePayload caps a server-claimed payload size before it reaches an
+	// allocation. It applies only to data the server says it will send, never to
+	// client-requested buffer sizes. Legitimate frames stay far below it (BLOB
+	// segments are at most 32000 bytes; info responses are bounded by the
+	// client's requested buffer size).
+	maxWirePayload = 1 << 24 // 16 MiB
+
+	// fetchRowBatchSize is the row count opFetch requests per op_fetch call.
+	// opFetchResponse caps its pre-allocation hint at this value; a well-behaved
+	// server never returns more rows than the driver asked for.
+	fetchRowBatchSize = 400
 )
 
 func _INFO_SQL_SELECT_DESCRIBE_VARS() []byte {
@@ -348,6 +360,10 @@ func (p *wireProtocol) _parse_status_vector() (statusVector, error) {
 				return sv, err
 			}
 			nbytes := int(bytes_to_bint32(b))
+			if nbytes < 0 || nbytes > maxWirePayload {
+				// Malformed length: wire position is now undefined, so flag ErrBadConn to keep this conn out of the pool.
+				return sv, fmt.Errorf("firebirdsql: status vector string length %d out of range: %w", nbytes, driver.ErrBadConn)
+			}
 			b, err = p.recvPacketsAlignment(nbytes)
 			if err != nil {
 				return sv, err
@@ -366,6 +382,10 @@ func (p *wireProtocol) _parse_status_vector() (statusVector, error) {
 				return sv, err
 			}
 			nbytes := int(bytes_to_bint32(b))
+			if nbytes < 0 || nbytes > maxWirePayload {
+				// as above
+				return sv, fmt.Errorf("firebirdsql: status vector string length %d out of range: %w", nbytes, driver.ErrBadConn)
+			}
 			b, err = p.recvPacketsAlignment(nbytes)
 			if err != nil {
 				return sv, err
@@ -379,6 +399,10 @@ func (p *wireProtocol) _parse_status_vector() (statusVector, error) {
 				return sv, err
 			}
 			nbytes := int(bytes_to_bint32(b))
+			if nbytes < 0 || nbytes > maxWirePayload {
+				// as above
+				return sv, fmt.Errorf("firebirdsql: status vector string length %d out of range: %w", nbytes, driver.ErrBadConn)
+			}
 			b, err = p.recvPacketsAlignment(nbytes)
 			if err != nil {
 				return sv, err
@@ -407,6 +431,12 @@ func (p *wireProtocol) _parse_op_response() (int32, []byte, []byte, error) {
 	h := bytes_to_bint32(b[0:4])            // Object handle
 	oid := b[4:12]                          // Object ID
 	buf_len := int(bytes_to_bint32(b[12:])) // Buffer length
+
+	// Reject a malformed buffer length before it reaches an allocation. A
+	// negative value never allocates (the > 0 gate below) but is still malformed.
+	if buf_len < 0 || buf_len > maxWirePayload {
+		return h, oid, nil, fmt.Errorf("firebirdsql: response buffer length %d out of range: %w", buf_len, driver.ErrBadConn)
+	}
 
 	// Receive data buffer if length is greater than zero
 	var buf []byte
@@ -511,6 +541,21 @@ func (p *wireProtocol) _guess_wire_crypt(buf []byte, clientPlugins []string) (st
 	return "", nil
 }
 
+// recvHandshakeBlob reads one length-prefixed field of a connect/cont-auth
+// response, validating the 4-byte length before allocating: a negative value
+// or one above maxWirePayload is a protocol error, not a make() panic.
+func (p *wireProtocol) recvHandshakeBlob(what string) ([]byte, error) {
+	b, err := p.recvPackets(4)
+	if err != nil {
+		return nil, fmt.Errorf("firebirdsql: reading %s length: %w", what, err)
+	}
+	ln := int(bytes_to_bint32(b))
+	if ln < 0 || ln > maxWirePayload {
+		return nil, fmt.Errorf("firebirdsql: %s length %d out of range", what, ln)
+	}
+	return p.recvPacketsAlignment(ln)
+}
+
 func (p *wireProtocol) _parse_connect_response(user string, password string, options map[string]string, clientPublic *big.Int, clientSecret *big.Int) (err error) {
 	p.debugPrint("_parse_connect_response")
 
@@ -558,24 +603,25 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 	var nonce []byte
 
 	if opcode == op_cond_accept || opcode == op_accept_data {
-		var readLength, ln int
+		var data []byte
+		if data, err = p.recvHandshakeBlob("accept auth data"); err != nil {
+			return
+		}
 
-		b, _ := p.recvPackets(4)
-		ln = int(bytes_to_bint32(b))
-		data, _ := p.recvPacketsAlignment(ln)
-
-		b, _ = p.recvPackets(4)
-		ln = int(bytes_to_bint32(b))
-		pluginName, _ := p.recvPacketsAlignment(ln)
+		var pluginName []byte
+		if pluginName, err = p.recvHandshakeBlob("accept plugin name"); err != nil {
+			return
+		}
 		p.pluginName = bytes_to_str(pluginName)
 
-		b, _ = p.recvPackets(4)
+		if b, err = p.recvPackets(4); err != nil {
+			return
+		}
 		isAuthenticated := bytes_to_bint32(b)
-		readLength += 4
 
-		b, _ = p.recvPackets(4)
-		ln = int(bytes_to_bint32(b))
-		_, _ = p.recvPacketsAlignment(ln) // keys
+		if _, err = p.recvHandshakeBlob("accept keys"); err != nil {
+			return
+		}
 
 		if isAuthenticated == 0 {
 			// Refuse a server-selected auth plugin the client never sanctioned,
@@ -595,7 +641,9 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 
 				if len(data) == 0 {
 					p.opContAuth(bigIntToBytes(clientPublic), p.pluginName, options["auth_plugin_list"], "")
-					b, _ := p.recvPackets(4)
+					if b, err = p.recvPackets(4); err != nil {
+						return
+					}
 					op := bytes_to_bint32(b)
 					if op == op_response {
 						_, _, _, err = p._parse_op_response() // error occurred
@@ -607,28 +655,36 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 						return
 					}
 
-					b, _ = p.recvPackets(4)
-					ln = int(bytes_to_bint32(b))
-					data, _ = p.recvPacketsAlignment(ln)
-
-					b, _ = p.recvPackets(4)
-					ln = int(bytes_to_bint32(b))
-					_, _ = p.recvPacketsAlignment(ln) // pluginName
-
-					b, _ = p.recvPackets(4)
-					ln = int(bytes_to_bint32(b))
-					_, _ = p.recvPacketsAlignment(ln) // pluginList
-
-					b, _ = p.recvPackets(4)
-					ln = int(bytes_to_bint32(b))
-					_, _ = p.recvPacketsAlignment(ln) // keys
+					if data, err = p.recvHandshakeBlob("cont-auth data"); err != nil {
+						return
+					}
+					if _, err = p.recvHandshakeBlob("cont-auth plugin name"); err != nil {
+						return
+					}
+					if _, err = p.recvHandshakeBlob("cont-auth plugin list"); err != nil {
+						return
+					}
+					if _, err = p.recvHandshakeBlob("cont-auth keys"); err != nil {
+						return
+					}
 				}
 				if len(data) == 0 {
 					err = errors.New("Your user name and password are not defined. Ask your database administrator to set up a Firebird login.\n")
 					return
 				}
 
-				ln = int(bytes_to_int16(data[:2]))
+				// Validate the salt length and the two slice offsets below against the
+				// bytes actually received before slicing.
+				if len(data) < 2 {
+					err = fmt.Errorf("firebirdsql: SRP server auth data too short (%d bytes)", len(data))
+					return
+				}
+				// USHORT on the wire: read unsigned so it can never present as negative.
+				ln := int(bytes_to_uint16(data[:2]))
+				if 4+ln > len(data) {
+					err = fmt.Errorf("firebirdsql: SRP salt length %d inconsistent with server auth data (%d bytes)", ln, len(data))
+					return
+				}
 				serverSalt := data[2 : ln+2]
 				serverPublic := bigIntFromHexString(bytes_to_str(data[4+ln:]))
 				authData, sessionKey = getClientProof(strings.ToUpper(user), password, serverSalt, clientPublic, serverPublic, clientSecret, p.pluginName)
@@ -689,78 +745,128 @@ func (p *wireProtocol) _parse_connect_response(user string, password string, opt
 	return
 }
 
+// _parse_select_items decodes a describe-vars response (the per-column
+// metadata Firebird sends after op_info_sql for a SELECT or bind list). Every
+// item length and column index is bounds-checked against buf and xsqlda before
+// use. An unrecognized item type is skipped (after its length-prefixed payload
+// is bounds-checked) rather than rejected, so a newer server that adds an item
+// type this driver predates doesn't break every describe response.
 func (p *wireProtocol) _parse_select_items(buf []byte, xsqlda []xSQLVAR) (int, error) {
-	var err error
-	var ln int
 	index := 0
+	// requireIndex guards the xsqlda[index-1] writes: only items that index into
+	// xsqlda call it, so an unrecognized item can be skipped even before any
+	// isc_info_sql_sqlda_seq has set index.
+	requireIndex := func(item int) error {
+		if index < 1 || index > len(xsqlda) {
+			return fmt.Errorf("firebirdsql: describe-vars item 0x%02x with invalid index %d", item, index)
+		}
+		return nil
+	}
 	i := 0
-	for item := int(buf[i]); item != isc_info_end; item = int(buf[i]) {
+	for i < len(buf) {
+		item := int(buf[i])
+		if item == isc_info_end {
+			break
+		}
+		if item == isc_info_truncated {
+			return index, nil // caller issues a continuation request
+		}
+		if item == isc_info_sql_describe_end {
+			i++
+			continue
+		}
 		i++
+		if i+2 > len(buf) {
+			return -1, fmt.Errorf("firebirdsql: truncated describe-vars item 0x%02x", item)
+		}
+		// USHORT on the wire: read unsigned so it can never present as negative.
+		ln := int(bytes_to_uint16(buf[i : i+2]))
+		i += 2
+		if i+ln > len(buf) {
+			return -1, fmt.Errorf("firebirdsql: invalid describe-vars length %d for item 0x%02x", ln, item)
+		}
+		payload := buf[i : i+ln]
+		i += ln
+
 		switch item {
 		case isc_info_sql_sqlda_seq:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			index = int(bytes_to_int32(buf[i : i+ln]))
-			i += ln
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short sqlda_seq payload (%d bytes)", ln)
+			}
+			index = int(bytes_to_int32(payload))
+			if index < 1 || index > len(xsqlda) {
+				return -1, fmt.Errorf("firebirdsql: sqlda_seq %d out of range [1,%d]", index, len(xsqlda))
+			}
 		case isc_info_sql_type:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			sqltype := int(bytes_to_int32(buf[i : i+ln]))
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short sql_type payload (%d bytes)", ln)
+			}
+			sqltype := int(bytes_to_int32(payload))
 			if sqltype%2 != 0 {
 				sqltype--
 			}
 			xsqlda[index-1].sqltype = sqltype
-			i += ln
 		case isc_info_sql_sub_type:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].sqlsubtype = int(bytes_to_int32(buf[i : i+ln]))
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short sub_type payload (%d bytes)", ln)
+			}
+			xsqlda[index-1].sqlsubtype = int(bytes_to_int32(payload))
 		case isc_info_sql_scale:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].sqlscale = int(bytes_to_int32(buf[i : i+ln]))
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short scale payload (%d bytes)", ln)
+			}
+			xsqlda[index-1].sqlscale = int(bytes_to_int32(payload))
 		case isc_info_sql_length:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short length payload (%d bytes)", ln)
+			}
 			// the length defined in buffer depends on character length of charset
-			xsqlda[index-1].sqllen = int(bytes_to_int32(buf[i : i+ln]))
-			i += ln
+			xsqlda[index-1].sqllen = int(bytes_to_int32(payload))
 		case isc_info_sql_null_ind:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].null_ok = bytes_to_int32(buf[i:i+ln]) != 0
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			if ln < 4 {
+				return -1, fmt.Errorf("firebirdsql: short null_ind payload (%d bytes)", ln)
+			}
+			xsqlda[index-1].null_ok = bytes_to_int32(payload) != 0
 		case isc_info_sql_field:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].fieldname = bytes_to_str(buf[i : i+ln])
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			xsqlda[index-1].fieldname = bytes_to_str(payload)
 		case isc_info_sql_relation:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].relname = bytes_to_str(buf[i : i+ln])
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			xsqlda[index-1].relname = bytes_to_str(payload)
 		case isc_info_sql_owner:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].ownname = bytes_to_str(buf[i : i+ln])
-			i += ln
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			xsqlda[index-1].ownname = bytes_to_str(payload)
 		case isc_info_sql_alias:
-			ln = int(bytes_to_int16(buf[i : i+2]))
-			i += 2
-			xsqlda[index-1].aliasname = bytes_to_str(buf[i : i+ln])
-			i += ln
-		case isc_info_truncated:
-			return index, err // return next index
-		case isc_info_sql_describe_end:
-			/* NOTHING */
+			if err := requireIndex(item); err != nil {
+				return -1, err
+			}
+			xsqlda[index-1].aliasname = bytes_to_str(payload)
 		default:
-			err = fmt.Errorf("Invalid item [%02x] ! i=%d", buf[i], i)
+			// Unknown item: payload already bounds-checked and skipped above; nothing to do.
 		}
 	}
-	return -1, err // no more info
+	return -1, nil
 }
 
 func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQLVAR, error) {
@@ -771,17 +877,35 @@ func (p *wireProtocol) parse_xsqlda(buf []byte, stmtHandle int32) (int32, []xSQL
 	i := 0
 
 	for i < len(buf) {
-		if buf[i] == byte(isc_info_sql_stmt_type) && buf[i+1] == byte(0x04) && buf[i+2] == byte(0x00) {
+		// The leading i+3<=len(buf) / i+2<=len(buf) conjuncts keep the buf[i+1]/buf[i+2]
+		// lookahead from running past buf when too few bytes remain; an incomplete
+		// header then falls through to the "else break" like any unrecognized tag.
+		if i+3 <= len(buf) && buf[i] == byte(isc_info_sql_stmt_type) && buf[i+1] == byte(0x04) && buf[i+2] == byte(0x00) {
 			i++
-			ln = int(bytes_to_int16(buf[i : i+2]))
+			// USHORT on the wire: read unsigned so it can never be negative. The ln<4
+			// check below guarantees the 4 bytes bytes_to_int32 reads unconditionally.
+			ln = int(bytes_to_uint16(buf[i : i+2]))
 			i += 2
+			if ln < 4 || i+ln > len(buf) {
+				return stmt_type, nil, fmt.Errorf("firebirdsql: invalid sql_stmt_type payload length %d", ln)
+			}
 			stmt_type = int32(bytes_to_int32(buf[i : i+ln]))
 			i += ln
-		} else if buf[i] == byte(isc_info_sql_select) && buf[i+1] == byte(isc_info_sql_describe_vars) {
+		} else if i+2 <= len(buf) && buf[i] == byte(isc_info_sql_select) && buf[i+1] == byte(isc_info_sql_describe_vars) {
 			i += 2
-			ln = int(bytes_to_int16(buf[i : i+2]))
+			if i+2 > len(buf) {
+				return stmt_type, nil, fmt.Errorf("firebirdsql: truncated select describe-vars length")
+			}
+			ln = int(bytes_to_uint16(buf[i : i+2]))
 			i += 2
+			if ln < 4 || i+ln > len(buf) {
+				return stmt_type, nil, fmt.Errorf("firebirdsql: invalid select describe column-count length %d", ln)
+			}
 			col_len = int(bytes_to_int32(buf[i : i+ln]))
+			// col_len drives an allocation; apply the same bound _fetchBindXsqlda uses.
+			if col_len < 0 || col_len > 65535 {
+				return stmt_type, nil, fmt.Errorf("firebirdsql: invalid select describe column count %d", col_len)
+			}
 			xsqlda = make([]xSQLVAR, col_len)
 			next_index, err = p._parse_select_items(buf[i+ln:], xsqlda)
 			if err != nil {
@@ -897,9 +1021,24 @@ func (p *wireProtocol) getBlobSegments(blobId []byte, transHandle int32) ([]byte
 	for more_data != 2 {
 		p.opGetSegment(blobHandle)
 		more_data, _, rbuf, err = p.opResponse()
+		if err != nil {
+			// A server-reported error (FbError) arrives in a fully parsed frame, so return
+			// it as-is; without this the loop re-issued op_get_segment forever on an error.
+			p.resumeBuffer(suspendBuf)
+			return nil, err
+		}
 		buf := rbuf
 		for len(buf) > 0 {
-			ln := int(bytes_to_int16(buf[0:2]))
+			// Each segment is a USHORT length followed by data; validate the length before slicing.
+			if len(buf) < 2 {
+				p.resumeBuffer(suspendBuf)
+				return nil, fmt.Errorf("firebirdsql: BLOB segment header truncated (%d trailing bytes): %w", len(buf), driver.ErrBadConn)
+			}
+			ln := int(bytes_to_uint16(buf[0:2]))
+			if ln+2 > len(buf) {
+				p.resumeBuffer(suspendBuf)
+				return nil, fmt.Errorf("firebirdsql: BLOB segment length %d exceeds response (%d bytes left): %w", ln, len(buf), driver.ErrBadConn)
+			}
 			blob = append(blob, buf[2:ln+2]...)
 			buf = buf[ln+2:]
 		}
@@ -1268,7 +1407,7 @@ func (p *wireProtocol) opFetch(stmtHandle int32, blr []byte) error {
 	p.packInt(stmtHandle)
 	p.packBytes(blr)
 	p.packInt(0)
-	p.packInt(400)
+	p.packInt(fetchRowBatchSize)
 	_, err := p.sendPackets()
 	return err
 }
@@ -1288,6 +1427,11 @@ func (p *wireProtocol) readRow(xsqlda []xSQLVAR) ([]driver.Value, error) {
 				ln = int(bytes_to_bint32(b))
 			} else {
 				ln = x.ioLength()
+			}
+			// ln comes from the wire (variable-length columns) or the describe (fixed ones).
+			// Reject rather than clamp: this is a streaming read, so under-consuming desyncs the wire.
+			if ln < 0 || ln > maxWirePayload {
+				return nil, fmt.Errorf("firebirdsql: column data length %d out of range: %w", ln, driver.ErrBadConn)
 			}
 			rawValue, err := p.recvPacketsAlignment(ln)
 			if err != nil {
@@ -1324,6 +1468,10 @@ func (p *wireProtocol) readRow(xsqlda []xSQLVAR) ([]driver.Value, error) {
 			} else {
 				ln = x.ioLength()
 			}
+			// Same guard as the branch above.
+			if ln < 0 || ln > maxWirePayload {
+				return nil, fmt.Errorf("firebirdsql: column data length %d out of range: %w", ln, driver.ErrBadConn)
+			}
 			rawValue, err := p.recvPacketsAlignment(ln)
 			if err != nil {
 				return nil, err
@@ -1341,6 +1489,9 @@ func (p *wireProtocol) readRow(xsqlda []xSQLVAR) ([]driver.Value, error) {
 func (p *wireProtocol) opFetchResponse(stmtHandle int32, transHandle int32, xsqlda []xSQLVAR) ([][]driver.Value, bool, error) {
 	p.debugPrint("opFetchResponse")
 	b, err := p.recvPackets(4)
+	if err != nil {
+		return nil, false, fmt.Errorf("firebirdsql: reading fetch response header: %w", errors.Join(err, driver.ErrBadConn))
+	}
 	for bytes_to_bint32(b) == op_dummy {
 		b, _ = p.recvPackets(4)
 	}
@@ -1362,9 +1513,17 @@ func (p *wireProtocol) opFetchResponse(stmtHandle int32, transHandle int32, xsql
 		return nil, false, errors.New("opFetchResponse:Internal Error")
 	}
 	b, err = p.recvPackets(8)
+	if err != nil {
+		return nil, false, err
+	}
 	status := bytes_to_bint32(b[:4])
 	count := int(bytes_to_bint32(b[4:8]))
-	rows := make([][]driver.Value, 0, count) // pre-allocate to known chunk size
+	if count < 0 {
+		return nil, false, fmt.Errorf("firebirdsql: fetch response row count %d out of range: %w", count, driver.ErrBadConn)
+	}
+	// Cap the pre-allocation at fetchRowBatchSize (the rows one op_fetch requests).
+	// The append loop is data-driven, so this bounds only initial capacity, not the result.
+	rows := make([][]driver.Value, 0, min(count, fetchRowBatchSize))
 
 	for count > 0 {
 		r, err2 := p.readRow(xsqlda)

--- a/wireprotocol_parse_test.go
+++ b/wireprotocol_parse_test.go
@@ -1,0 +1,435 @@
+package firebirdsql
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/binary"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for wire-protocol parsing of server-supplied lengths.
+// No live Firebird server required.
+// ---------------------------------------------------------------------------
+
+func TestParseStatusVector_BadStringLength(t *testing.T) {
+	cases := []struct {
+		name   string
+		length int32
+	}{
+		{"negative", -1},
+		{"over cap", maxWirePayload + 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb statusBuf
+			sb.gds(335544665)
+			sb.tag(isc_arg_string)
+			sb.int32(tt.length) // claimed string length; no payload follows
+
+			_, err := testProtocol(sb.bytes())._parse_status_vector()
+			if err == nil {
+				t.Fatal("expected error for malformed string length, got nil")
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("unexpected error: %v", err)
+			}
+			// The wire is desynced; the conn must be evicted from the pool.
+			if !errors.Is(err, driver.ErrBadConn) {
+				t.Errorf("error should report a bad connection, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseStatusVector_TruncatedString(t *testing.T) {
+	var sb statusBuf
+	sb.gds(335544665)
+	sb.tag(isc_arg_string)
+	sb.int32(100) // claims 100 bytes but the stream ends here
+
+	_, err := testProtocol(sb.bytes())._parse_status_vector()
+	if err == nil {
+		t.Fatal("expected error for truncated string payload, got nil")
+	}
+}
+
+func TestParseOpResponse_BadBufferLength(t *testing.T) {
+	cases := []struct {
+		name   string
+		length int32
+	}{
+		{"negative", -1},
+		{"over cap", maxWirePayload + 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var f acceptFrame
+			f.int32(7)                   // object handle
+			f.buf.Write(make([]byte, 8)) // object id
+			f.int32(tt.length)           // claimed buffer length; nothing follows
+
+			_, _, _, err := testProtocol(f.bytes())._parse_op_response()
+			if err == nil {
+				t.Fatal("expected error for malformed buffer length, got nil")
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !errors.Is(err, driver.ErrBadConn) {
+				t.Errorf("error should report a bad connection, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestOpFetchResponse_ValidRows(t *testing.T) {
+	var f acceptFrame
+	f.int32(op_fetch_response)
+	f.int32(0)                         // status: cursor still open
+	f.int32(1)                         // one row in this chunk
+	f.buf.Write([]byte{0x00, 0, 0, 0}) // null bitmap (V13+), aligned
+	f.buf.Write([]byte{42, 0, 0, 0})   // SQL_LONG value, little-endian
+	f.int32(op_fetch_response)
+	f.int32(100) // status: end of cursor
+	f.int32(0)
+
+	p := testProtocol(f.bytes())
+	p.protocolVersion = PROTOCOL_VERSION13
+	rows, more, err := p.opFetchResponse(1, 1, []xSQLVAR{{sqltype: SQL_TYPE_LONG}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows: got %d, want 1", len(rows))
+	}
+	if more {
+		t.Error("more: got true, want false")
+	}
+}
+
+func TestOpFetchResponse_NegativeRowCount(t *testing.T) {
+	var f acceptFrame
+	f.int32(op_fetch_response)
+	f.int32(0)  // status
+	f.int32(-1) // claimed row count
+
+	_, _, err := testProtocol(f.bytes()).opFetchResponse(1, 1, nil)
+	if err == nil {
+		t.Fatal("expected error for negative row count, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !errors.Is(err, driver.ErrBadConn) {
+		t.Errorf("error should report a bad connection, got: %v", err)
+	}
+}
+
+func TestOpFetchResponse_HugeRowCount(t *testing.T) {
+	// An absurd claimed count must not drive the pre-allocation; the loop is
+	// data-driven, so the truncated stream surfaces as a clean read error.
+	var f acceptFrame
+	f.int32(op_fetch_response)
+	f.int32(0)
+	f.int32(0x7FFFFFFF)
+
+	p := testProtocol(f.bytes())
+	p.protocolVersion = PROTOCOL_VERSION13
+	_, _, err := p.opFetchResponse(1, 1, []xSQLVAR{{sqltype: SQL_TYPE_LONG}})
+	if err == nil {
+		t.Fatal("expected error for truncated stream, got nil")
+	}
+}
+
+func TestReadRow_BadColumnLength(t *testing.T) {
+	cases := []struct {
+		name string
+		ln   int32
+	}{
+		{"negative", -5},
+		{"over cap", maxWirePayload + 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var f acceptFrame
+			f.buf.Write([]byte{0x00, 0, 0, 0}) // null bitmap: column present
+			f.int32(tt.ln)                     // claimed varying-column length
+
+			p := testProtocol(f.bytes())
+			p.protocolVersion = PROTOCOL_VERSION13
+			_, err := p.readRow([]xSQLVAR{{sqltype: SQL_TYPE_VARYING}})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !errors.Is(err, driver.ErrBadConn) {
+				t.Errorf("error should report a bad connection, got: %v", err)
+			}
+		})
+	}
+}
+
+// acceptFrame builds the byte stream of a connect-response packet
+// (op_accept_data and friends) as the server would send it.
+type acceptFrame struct{ buf bytes.Buffer }
+
+func (f *acceptFrame) int32(v int32) { _ = binary.Write(&f.buf, binary.BigEndian, v) }
+
+// blob writes a 4-byte length-prefixed field with 4-byte alignment padding.
+func (f *acceptFrame) blob(b []byte) {
+	f.int32(int32(len(b)))
+	f.buf.Write(b)
+	if pad := (4 - len(b)%4) % 4; pad > 0 {
+		f.buf.Write(make([]byte, pad))
+	}
+}
+
+// acceptHeader writes the opcode plus the 12-byte version/architecture/type block.
+func (f *acceptFrame) acceptHeader(opcode int32) {
+	f.int32(opcode)
+	f.int32(PROTOCOL_VERSION13) // version byte ends up in b[3]
+	f.int32(1)                  // accept architecture
+	f.int32(0)                  // accept type (no compression flag)
+}
+
+func (f *acceptFrame) bytes() []byte { return f.buf.Bytes() }
+
+func testConnectOptions() map[string]string {
+	return map[string]string{
+		"auth_plugin_name":  "Srp256",
+		"auth_plugin_list":  defaultAuthPlugins,
+		"wire_crypt":        "true",
+		"wire_crypt_plugin": defaultWireCryptPlugins,
+	}
+}
+
+// srpServerData builds the auth-data payload of an op_accept_data response:
+// 2-byte little-endian salt length, salt, 2-byte key length, hex-encoded key.
+func srpServerData(saltLen int, keyHexLen int) []byte {
+	data := []byte{byte(saltLen & 0xFF), byte(saltLen >> 8)}
+	salt := bytes.Repeat([]byte{0x01}, saltLen)
+	data = append(data, salt...)
+	data = append(data, byte(keyHexLen&0xFF), byte(keyHexLen>>8))
+	data = append(data, bytes.Repeat([]byte{'a'}, keyHexLen)...)
+	return data
+}
+
+func parseConnectResponse(t *testing.T, frame []byte) error {
+	t.Helper()
+	p := testProtocol(frame)
+	clientPublic, clientSecret, err := getClientSeed()
+	if err != nil {
+		t.Fatalf("getClientSeed: %v", err)
+	}
+	return p._parse_connect_response("SYSDBA", "masterkey", testConnectOptions(), clientPublic, clientSecret)
+}
+
+// opResponseFrame appends one op_response packet: object handle, object id,
+// length-prefixed data buffer, and a status vector with the given entries
+// (empty = success).
+func (f *acceptFrame) opResponseFrame(handle int32, data []byte, statusVector ...int32) {
+	f.int32(op_response)
+	f.int32(handle)
+	f.buf.Write(make([]byte, 8)) // object id
+	f.blob(data)
+	for _, v := range statusVector {
+		f.int32(v)
+	}
+	f.int32(isc_arg_end)
+}
+
+func TestGetBlobSegments_Valid(t *testing.T) {
+	var f acceptFrame
+	f.opResponseFrame(1, nil) // op_open_blob2 response: blob handle 1
+	// Final op_get_segment response (handle 2 = blob end) legitimately carries
+	// several length-prefixed segments concatenated in one buffer.
+	f.opResponseFrame(2, []byte{3, 0, 'a', 'b', 'c', 2, 0, 'd', 'e'})
+	f.opResponseFrame(0, nil) // op_close_blob response
+
+	blob, err := testProtocol(f.bytes()).getBlobSegments(make([]byte, 8), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(blob) != "abcde" {
+		t.Errorf("blob: got %q, want %q", blob, "abcde")
+	}
+}
+
+func TestGetBlobSegments_MalformedSegment(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		wantSub string
+	}{
+		{"length past end", []byte{5, 0, 'a'}, "exceeds response"},
+		{"truncated header", []byte{7}, "truncated"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var f acceptFrame
+			f.opResponseFrame(1, nil)
+			f.opResponseFrame(2, tt.payload)
+
+			p := testProtocol(f.bytes())
+			sentinel := []byte{0xAA, 0xBB}
+			p.buf = sentinel
+
+			_, err := p.getBlobSegments(make([]byte, 8), 1)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !errors.Is(err, driver.ErrBadConn) {
+				t.Errorf("error should report a bad connection, got: %v", err)
+			}
+			// The suspended send buffer must be restored on every error path.
+			if !bytes.Equal(p.buf, sentinel) {
+				t.Errorf("wire buffer not restored: %v", p.buf)
+			}
+		})
+	}
+}
+
+func TestGetBlobSegments_ServerErrorMidStream(t *testing.T) {
+	var f acceptFrame
+	f.opResponseFrame(1, nil)
+	// op_get_segment response whose status vector carries a server error;
+	// previously the loop ignored it and re-issued op_get_segment forever.
+	f.opResponseFrame(0, nil, isc_arg_gds, 335544336 /* deadlock */)
+
+	p := testProtocol(f.bytes())
+	sentinel := []byte{0xCC}
+	p.buf = sentinel
+
+	_, err := p.getBlobSegments(make([]byte, 8), 1)
+	var fbErr *FbError
+	if !errors.As(err, &fbErr) {
+		t.Fatalf("want *FbError, got %T: %v", err, err)
+	}
+	// The error frame was fully parsed, so the connection stays usable.
+	if errors.Is(err, driver.ErrBadConn) {
+		t.Errorf("clean server error must not poison the connection: %v", err)
+	}
+	if !bytes.Equal(p.buf, sentinel) {
+		t.Errorf("wire buffer not restored: %v", p.buf)
+	}
+}
+
+func TestParseConnectResponse_ValidSRPAcceptData(t *testing.T) {
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	f.blob(srpServerData(32, 256)) // 292-byte blob: the shape real servers send
+	f.blob([]byte("Srp256"))
+	f.int32(0) // not yet authenticated
+	f.blob(nil)
+
+	if err := parseConnectResponse(t, f.bytes()); err != nil {
+		t.Fatalf("legitimate accept frame rejected: %v", err)
+	}
+}
+
+func TestParseConnectResponse_NegativeBlobLength(t *testing.T) {
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	f.int32(-1) // server claims a negative auth-data length
+
+	err := parseConnectResponse(t, f.bytes())
+	if err == nil {
+		t.Fatal("expected error for negative blob length, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseConnectResponse_OversizedBlobLength(t *testing.T) {
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	f.int32(maxWirePayload + 1) // absurd server-claimed length must not be allocated
+
+	err := parseConnectResponse(t, f.bytes())
+	if err == nil {
+		t.Fatal("expected error for oversized blob length, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseConnectResponse_TruncatedAcceptFields(t *testing.T) {
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	// Stream ends before the first length word: the read error must propagate
+	// instead of being dropped.
+	if err := parseConnectResponse(t, f.bytes()); err == nil {
+		t.Fatal("expected error for truncated accept frame, got nil")
+	}
+}
+
+func TestParseConnectResponse_SRPEmptyServerKey(t *testing.T) {
+	// Salt present but no key material after it: the key hex decodes to a
+	// zero public key, which must flow through the client proof computation
+	// without panicking (the zero-skip scan in pad is bounded).
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	f.blob(srpServerData(32, 0))
+	f.blob([]byte("Srp256"))
+	f.int32(0)
+	f.blob(nil)
+
+	if err := parseConnectResponse(t, f.bytes()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseConnectResponse_SRPDataTooShort(t *testing.T) {
+	var f acceptFrame
+	f.acceptHeader(op_accept_data)
+	f.blob([]byte{0x20}) // 1 byte: shorter than the salt-length field itself
+	f.blob([]byte("Srp256"))
+	f.int32(0)
+	f.blob(nil)
+
+	err := parseConnectResponse(t, f.bytes())
+	if err == nil {
+		t.Fatal("expected error for short SRP data, got nil")
+	}
+	if !strings.Contains(err.Error(), "too short") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseConnectResponse_SRPSaltLengthInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"negative salt length", []byte{0xFF, 0xFF}},
+		{"salt length past end", []byte{100, 0, 'x', 'x'}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var f acceptFrame
+			f.acceptHeader(op_accept_data)
+			f.blob(tt.data)
+			f.blob([]byte("Srp256"))
+			f.int32(0)
+			f.blob(nil)
+
+			err := parseConnectResponse(t, f.bytes())
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "salt length") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/wireprotocol_test.go
+++ b/wireprotocol_test.go
@@ -1,0 +1,308 @@
+package firebirdsql
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for _parse_select_items and parse_xsqlda's describe-vars
+// parsing of server-supplied lengths and column indices. No live Firebird
+// server required.
+// ---------------------------------------------------------------------------
+
+// descVarsBuf builds a minimal describe-vars buffer:
+// sqlda_seq=1, sql_type=sqltype, describe_end, isc_info_end.
+func descVarsBuf(sqltype int32) []byte {
+	buf := []byte{
+		isc_info_sql_sqlda_seq, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, // seq=1
+		isc_info_sql_type, 0x04, 0x00, // type tag + ln=4
+	}
+	buf = append(buf, int32_to_bytes(sqltype)...)
+	return append(buf, isc_info_sql_describe_end, isc_info_end)
+}
+
+func TestParseSelectItems(t *testing.T) {
+	wp := &wireProtocol{}
+
+	cases := []struct {
+		name         string
+		buf          []byte
+		slots        int
+		wantIndex    int
+		wantErr      string // substring; empty means no error
+		checkSqltype int    // if > 0, assert xsqlda[0].sqltype == this value
+		checkFn      func(*testing.T, []xSQLVAR)
+	}{
+		{
+			name:      "empty buffer",
+			buf:       []byte{},
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "",
+		},
+		{
+			name:      "only isc_info_end",
+			buf:       []byte{isc_info_end},
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "",
+		},
+		{
+			name:      "truncated mid-item (tag with no length bytes)",
+			buf:       []byte{isc_info_sql_sqlda_seq},
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "truncated",
+		},
+		{
+			name: "oversized length via unsigned overflow",
+			// sqlda_seq tag, length bytes 0xFF 0xFF = uint16(65535), then isc_info_end:
+			// far more than the one byte actually remaining in the buffer.
+			buf:       []byte{isc_info_sql_sqlda_seq, 0xFF, 0xFF, isc_info_end},
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "invalid describe-vars length",
+		},
+		{
+			name: "unknown tag with valid length+payload is skipped, not rejected",
+			// sqlda_seq=1 to set a valid index, then unknown tag 0xFE, ln=4;
+			// a newer Firebird version may add item types this driver
+			// predates, so an unrecognized tag must not abort the describe.
+			buf: func() []byte {
+				b := []byte{isc_info_sql_sqlda_seq, 0x04, 0x00}
+				b = append(b, int32_to_bytes(1)...)
+				return append(b, 0xFE, 0x04, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, isc_info_end)
+			}(),
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "",
+		},
+		{
+			name: "typed tag before sqlda_seq (index invalid guard)",
+			// sql_type tag before any sqlda_seq → index still 0
+			buf:       append([]byte{isc_info_sql_type, 0x04, 0x00}, append(int32_to_bytes(496), isc_info_end)...),
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "invalid index",
+		},
+		{
+			name:      "sqlda_seq out of range",
+			buf:       append([]byte{isc_info_sql_sqlda_seq, 0x04, 0x00}, append(int32_to_bytes(5), isc_info_end)...),
+			slots:     1,
+			wantIndex: -1,
+			wantErr:   "out of range",
+		},
+		{
+			name:         "valid minimal input",
+			buf:          descVarsBuf(496),
+			slots:        1,
+			wantIndex:    -1,
+			wantErr:      "",
+			checkSqltype: 496,
+		},
+		{
+			name:      "isc_info_truncated returns next index",
+			buf:       append([]byte{isc_info_sql_sqlda_seq, 0x04, 0x00}, append(int32_to_bytes(2), isc_info_truncated)...),
+			slots:     2,
+			wantIndex: 2,
+			wantErr:   "",
+		},
+		{
+			name: "multi-column sqlda_seq advances index",
+			buf: func() []byte {
+				b := []byte{
+					isc_info_sql_sqlda_seq, 0x04, 0x00,
+				}
+				b = append(b, int32_to_bytes(1)...)
+				b = append(b, isc_info_sql_type, 0x04, 0x00)
+				b = append(b, int32_to_bytes(496)...)
+				b = append(b, isc_info_sql_sqlda_seq, 0x04, 0x00)
+				b = append(b, int32_to_bytes(2)...)
+				b = append(b, isc_info_sql_type, 0x04, 0x00)
+				b = append(b, int32_to_bytes(452)...)
+				b = append(b, isc_info_sql_describe_end, isc_info_end)
+				return b
+			}(),
+			slots:     2,
+			wantIndex: -1,
+			wantErr:   "",
+			checkFn: func(t *testing.T, xsqlda []xSQLVAR) {
+				if xsqlda[0].sqltype != 496 {
+					t.Errorf("col1 sqltype: got %d, want 496", xsqlda[0].sqltype)
+				}
+				if xsqlda[1].sqltype != 452 {
+					t.Errorf("col2 sqltype: got %d, want 452", xsqlda[1].sqltype)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			xsqlda := make([]xSQLVAR, tc.slots)
+			gotIndex, gotErr := wp._parse_select_items(tc.buf, xsqlda)
+
+			if gotIndex != tc.wantIndex {
+				t.Errorf("index: got %d, want %d", gotIndex, tc.wantIndex)
+			}
+			if tc.wantErr == "" {
+				if gotErr != nil {
+					t.Errorf("unexpected error: %v", gotErr)
+				}
+			} else {
+				if gotErr == nil {
+					t.Errorf("expected error containing %q, got nil", tc.wantErr)
+				} else if !strings.Contains(gotErr.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", gotErr.Error(), tc.wantErr)
+				}
+			}
+			if tc.checkSqltype > 0 && xsqlda[0].sqltype != tc.checkSqltype {
+				t.Errorf("xsqlda[0].sqltype: got %d, want %d", xsqlda[0].sqltype, tc.checkSqltype)
+			}
+			if tc.checkFn != nil {
+				tc.checkFn(t, xsqlda)
+			}
+		})
+	}
+}
+
+func FuzzParseSelectItems(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{isc_info_end})
+	f.Add([]byte{isc_info_sql_sqlda_seq, 0xFF, 0xFF, isc_info_end})
+	f.Add([]byte{0xFE, 0x04, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, isc_info_end})
+	f.Add(descVarsBuf(496))
+	// short sqlda_seq payload (ln=2 < 4)
+	f.Add([]byte{isc_info_sql_sqlda_seq, 0x02, 0x00, 0xAA, 0xBB, isc_info_end})
+	// string tag before any sqlda_seq (index=0 guard)
+	f.Add([]byte{isc_info_sql_field, 0x03, 0x00, 'f', 'o', 'o', isc_info_end})
+
+	f.Fuzz(func(t *testing.T, buf []byte) {
+		wp := &wireProtocol{}
+		xsqlda := make([]xSQLVAR, 4)
+		idx, err := wp._parse_select_items(buf, xsqlda)
+		if err == nil {
+			if idx != -1 && (idx < 0 || idx > len(xsqlda)) {
+				t.Fatalf("returned index %d out of bounds for slots=%d", idx, len(xsqlda))
+			}
+		}
+	})
+}
+
+// parseXsqldaFrame builds the byte stream parse_xsqlda reads directly (it is
+// called with the raw info-response buffer, not through opResponse/testProtocol).
+func parseXsqldaFrame(colLen int32, items []byte) []byte {
+	buf := []byte{
+		isc_info_sql_stmt_type, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, // stmt_type=1
+		isc_info_sql_select, isc_info_sql_describe_vars,
+		0x04, 0x00, // ln=4
+	}
+	buf = append(buf, int32_to_bytes(colLen)...)
+	buf = append(buf, items...)
+	return buf
+}
+
+func TestParseXsqlda_BadColumnCount(t *testing.T) {
+	wp := &wireProtocol{}
+	cases := []struct {
+		name   string
+		colLen int32
+	}{
+		{"negative", -1},
+		{"over cap", 65536},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := parseXsqldaFrame(tt.colLen, []byte{isc_info_end})
+			_, _, err := wp.parse_xsqlda(buf, 1)
+			if err == nil {
+				t.Fatal("expected error for malformed column count, got nil")
+			}
+			if !strings.Contains(err.Error(), "invalid select describe column count") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseXsqlda_Valid(t *testing.T) {
+	wp := &wireProtocol{}
+	buf := parseXsqldaFrame(1, descVarsBuf(496))
+	stmtType, xsqlda, err := wp.parse_xsqlda(buf, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stmtType != 1 {
+		t.Errorf("stmtType: got %d, want 1", stmtType)
+	}
+	if len(xsqlda) != 1 || xsqlda[0].sqltype != 496 {
+		t.Errorf("xsqlda: got %+v, want one column with sqltype 496", xsqlda)
+	}
+}
+
+// TestParseXsqlda_TruncatedOrMalformed exercises the panic vectors a hostile
+// or truncated Prepare response can hit: the outer header scan indexes
+// buf[i+1]/buf[i+2] once the leading tag byte matches, and both the
+// stmt_type and select-describe-vars branches slice buf[i:i+ln] using a
+// server-controlled length before the byte count is known to be safe.
+//
+// Uses testProtocol (a real, discard-backed conn) rather than a bare
+// &wireProtocol{}: a well-formed sqlda_seq followed by isc_info_truncated
+// makes parse_xsqlda take its "more describe vars" continuation branch,
+// which sends a real opInfoSql request — that's a legitimate protocol path
+// requiring a connection, not a parser bug, and a bare wireProtocol's nil
+// conn would nil-deref there instead of exercising the guards under test.
+func TestParseXsqlda_TruncatedOrMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"single stmt_type tag byte, no lookahead", []byte{isc_info_sql_stmt_type}},
+		{"single select tag byte, no lookahead", []byte{isc_info_sql_select}},
+		{"stmt_type tag with unexpected length header bytes falls through cleanly",
+			[]byte{isc_info_sql_stmt_type, 0x05, 0x00}},
+		{"stmt_type payload shorter than the buffer holds",
+			[]byte{isc_info_sql_stmt_type, 0x04, 0x00, 0x01, 0x00}},
+		{"select tag with missing second byte", []byte{isc_info_sql_select}},
+		{"select tag with wrong second byte falls through cleanly",
+			[]byte{isc_info_sql_select, 0xFF}},
+		{"select describe-vars length truncated before the 2-byte field",
+			[]byte{isc_info_sql_select, isc_info_sql_describe_vars, 0x04}},
+		{"select describe-vars length reads negative as signed int16",
+			[]byte{isc_info_sql_select, isc_info_sql_describe_vars, 0x00, 0x80}},
+		{"select describe-vars col_len payload past end of buffer",
+			[]byte{isc_info_sql_select, isc_info_sql_describe_vars, 0x04, 0x00, 0x01, 0x00}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("parse_xsqlda panicked on %q: %v", tt.name, r)
+				}
+			}()
+			wp := testProtocol(nil)
+			_, _, _ = wp.parse_xsqlda(tt.buf, 1)
+		})
+	}
+}
+
+func FuzzParseXsqlda(f *testing.F) {
+	f.Add(parseXsqldaFrame(1, descVarsBuf(496)))
+	f.Add([]byte{isc_info_sql_stmt_type})
+	f.Add([]byte{isc_info_sql_select})
+	f.Add([]byte{isc_info_sql_select, isc_info_sql_describe_vars, 0x00, 0x80})
+	f.Fuzz(func(t *testing.T, buf []byte) {
+		// See TestParseXsqlda_TruncatedOrMalformed: a well-formed
+		// sqlda_seq + isc_info_truncated can legitimately drive the
+		// "more describe vars" continuation branch, which needs a
+		// connection (testProtocol) rather than a bare wireProtocol.
+		wp := testProtocol(nil)
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("parse_xsqlda panicked: %v", r)
+			}
+		}()
+		_, _, _ = wp.parse_xsqlda(buf, 1)
+	})
+}

--- a/xpb.go
+++ b/xpb.go
@@ -23,11 +23,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package firebirdsql
 
+import "fmt"
+
 const xpbPreallocBufSize = 16
 
+// XPBReader is a cursor over a Firebird parameter block. The buffer may be
+// server-supplied (e.g. a service-info response), so every read is
+// bounds-checked: a read past the end consumes the rest of the buffer,
+// returns zero, and sets a sticky error. Callers that surface a read value
+// must check Err() — like bufio.Scanner, the cursor keeps returning zero
+// once a read fails, so Next()/End() loops terminate.
 type XPBReader struct {
 	buf []byte
 	pos int
+	err error
 }
 
 type XPBWriter struct {
@@ -35,7 +44,21 @@ type XPBWriter struct {
 }
 
 func NewXPBReader(buf []byte) *XPBReader {
-	return &XPBReader{buf, 0}
+	return &XPBReader{buf: buf}
+}
+
+// fail records the first out-of-bounds read and parks the cursor at the end so
+// later Next()/End() calls terminate any consumer loop.
+func (pb *XPBReader) fail(format string, args ...any) {
+	if pb.err == nil {
+		pb.err = fmt.Errorf("firebirdsql: "+format, args...)
+	}
+	pb.pos = len(pb.buf)
+}
+
+// Err returns the first bounds violation encountered, or nil.
+func (pb *XPBReader) Err() error {
+	return pb.err
 }
 
 func (pb *XPBReader) Next() (have bool, value byte) {
@@ -48,6 +71,10 @@ func (pb *XPBReader) Next() (have bool, value byte) {
 }
 
 func (pb *XPBReader) Skip(count int) {
+	if count < 0 || pb.pos+count > len(pb.buf) {
+		pb.fail("parameter block skip of %d out of range", count)
+		return
+	}
 	pb.pos += count
 }
 
@@ -56,30 +83,49 @@ func (pb *XPBReader) End() bool {
 }
 
 func (pb *XPBReader) Get() byte {
-	b := pb.buf[pb.pos]
-	return b
+	if pb.pos >= len(pb.buf) {
+		pb.fail("parameter block read past end")
+		return 0
+	}
+	return pb.buf[pb.pos]
 }
 
 func (pb *XPBReader) GetString() string {
 	l := int(pb.GetInt16())
+	if l < 0 || pb.pos+l > len(pb.buf) {
+		pb.fail("parameter block string length %d out of range", l)
+		return ""
+	}
 	s := bytes_to_str(pb.buf[pb.pos : pb.pos+l])
 	pb.pos += l
 	return s
 }
 
 func (pb *XPBReader) GetInt16() int16 {
+	if pb.pos+2 > len(pb.buf) {
+		pb.fail("parameter block int16 read past end")
+		return 0
+	}
 	r := bytes_to_int16(pb.buf[pb.pos : pb.pos+2])
 	pb.pos += 2
 	return r
 }
 
 func (pb *XPBReader) GetInt32() int32 {
+	if pb.pos+4 > len(pb.buf) {
+		pb.fail("parameter block int32 read past end")
+		return 0
+	}
 	r := bytes_to_int32(pb.buf[pb.pos : pb.pos+4])
 	pb.pos += 4
 	return r
 }
 
 func (pb *XPBReader) GetInt64() int64 {
+	if pb.pos+8 > len(pb.buf) {
+		pb.fail("parameter block int64 read past end")
+		return 0
+	}
 	r := bytes_to_int64(pb.buf[pb.pos : pb.pos+8])
 	pb.pos += 8
 	return r
@@ -87,6 +133,7 @@ func (pb *XPBReader) GetInt64() int64 {
 
 func (pb *XPBReader) Reset() {
 	pb.pos = 0
+	pb.err = nil
 }
 
 func NewXPBWriter() *XPBWriter {

--- a/xpb_test.go
+++ b/xpb_test.go
@@ -111,6 +111,64 @@ func TestXPBReader_Reset(t *testing.T) {
 	assert.Equal(t, "test", xpb.GetString())
 }
 
+func TestXPBReader_BoundsViolationSetsErr(t *testing.T) {
+	cases := []struct {
+		name string
+		read func(*XPBReader)
+	}{
+		{"GetInt16 past end", func(r *XPBReader) { r.GetInt16() }},
+		{"GetInt32 past end", func(r *XPBReader) { r.GetInt32() }},
+		{"GetInt64 past end", func(r *XPBReader) { r.GetInt64() }},
+		{"GetString length past end", func(r *XPBReader) { r.GetString() }},
+		{"Get past end", func(r *XPBReader) { r.Get() }},
+		{"Skip past end", func(r *XPBReader) { r.Skip(100) }},
+		{"Skip negative", func(r *XPBReader) { r.Skip(-1) }},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Empty buffer: every read runs immediately past the end.
+			r := NewXPBReader(nil)
+			tt.read(r) // must not panic
+			if r.Err() == nil {
+				t.Fatal("expected sticky error after bounds violation, got nil")
+			}
+			// The cursor must be parked at the end so consumer loops terminate.
+			if !r.End() {
+				t.Error("cursor not parked at end after violation")
+			}
+			if have, _ := r.Next(); have {
+				t.Error("Next() should report no data after a violation")
+			}
+		})
+	}
+}
+
+func TestXPBReader_NegativeStringLength(t *testing.T) {
+	// 0xFFFF parses as a negative int16 length; must fail, not panic.
+	r := NewXPBReader([]byte{0xFF, 0xFF, 'a', 'b'})
+	if s := r.GetString(); s != "" {
+		t.Errorf("got %q, want empty", s)
+	}
+	if r.Err() == nil {
+		t.Fatal("expected error for negative string length, got nil")
+	}
+}
+
+func TestXPBReader_ResetClearsErr(t *testing.T) {
+	r := NewXPBReader([]byte{0x05})
+	r.GetInt32() // past end -> sticky err
+	if r.Err() == nil {
+		t.Fatal("expected error")
+	}
+	r.Reset()
+	if r.Err() != nil {
+		t.Errorf("Reset should clear the sticky error, got: %v", r.Err())
+	}
+	if r.End() {
+		t.Error("Reset should rewind the cursor")
+	}
+}
+
 func TestNewXPBWriter(t *testing.T) {
 	w := NewXPBWriter()
 	require.NotNil(t, w)

--- a/xsqlvar.go
+++ b/xsqlvar.go
@@ -25,7 +25,9 @@ package firebirdsql
 
 import (
 	"bytes"
+	"database/sql/driver"
 	"encoding/binary"
+	"fmt"
 	"math/big"
 	"reflect"
 	"strings"
@@ -314,16 +316,27 @@ func (x *xSQLVAR) parseString(raw_value []byte, charset string) interface{} {
 	return raw_value
 }
 
-func (x *xSQLVAR) scaledIntValue(i int64) interface{} {
+// maxDecimalScale bounds sqlscale before it drives big.Int.Exp(10, sqlscale).
+// sqlscale comes off the wire in the describe response (see _parse_select_items'
+// isc_info_sql_scale case); Firebird's legitimate NUMERIC/DECIMAL scale never
+// exceeds 38 (FB4+; 18 older), so a larger value is rejected, not clamped.
+const maxDecimalScale = 38
+
+func (x *xSQLVAR) scaledIntValue(i int64) (interface{}, error) {
 	switch {
 	case x.sqlscale > 0:
+		if x.sqlscale > maxDecimalScale {
+			// Surfaces from inside readRow after the column's raw bytes were consumed but
+			// before the rest of the row is read — the conn is desynced, so mark it bad.
+			return nil, fmt.Errorf("firebirdsql: NUMERIC/DECIMAL scale %d out of range: %w", x.sqlscale, driver.ErrBadConn)
+		}
 		// Plain integer matches isql; formatDecimalGDA would emit "5E+2".
 		mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(x.sqlscale)), nil)
-		return new(big.Int).Mul(big.NewInt(i), mul).String()
+		return new(big.Int).Mul(big.NewInt(i), mul).String(), nil
 	case x.sqlscale < 0:
-		return formatDecimalGDA(new(big.Int).Abs(big.NewInt(i)), int32(x.sqlscale), i < 0, "")
+		return formatDecimalGDA(new(big.Int).Abs(big.NewInt(i)), int32(x.sqlscale), i < 0, ""), nil
 	default:
-		return i
+		return i, nil
 	}
 }
 
@@ -348,11 +361,11 @@ func (x *xSQLVAR) value(raw_value []byte, timezone string, charset string) (v in
 			v = x.parseString(raw_value, charset)
 		}
 	case SQL_TYPE_SHORT:
-		v = x.scaledIntValue(int64(int16(bytes_to_bint32(raw_value))))
+		v, err = x.scaledIntValue(int64(int16(bytes_to_bint32(raw_value))))
 	case SQL_TYPE_LONG:
-		v = x.scaledIntValue(int64(bytes_to_bint32(raw_value)))
+		v, err = x.scaledIntValue(int64(bytes_to_bint32(raw_value)))
 	case SQL_TYPE_INT64:
-		v = x.scaledIntValue(bytes_to_bint64(raw_value))
+		v, err = x.scaledIntValue(bytes_to_bint64(raw_value))
 	case SQL_TYPE_INT128:
 		n := new(big.Int).SetBytes(raw_value)
 		if raw_value[0]&0x80 != 0 {
@@ -362,6 +375,11 @@ func (x *xSQLVAR) value(raw_value []byte, timezone string, charset string) (v in
 		case x.sqlscale < 0:
 			v = formatDecimalGDA(new(big.Int).Abs(n), int32(x.sqlscale), n.Sign() < 0, "")
 		case x.sqlscale > 0:
+			if x.sqlscale > maxDecimalScale {
+				// Same desync hazard as scaledIntValue's identical guard above.
+				err = fmt.Errorf("firebirdsql: NUMERIC/DECIMAL scale %d out of range: %w", x.sqlscale, driver.ErrBadConn)
+				break
+			}
 			mul := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(x.sqlscale)), nil)
 			v = new(big.Int).Mul(n, mul).String()
 		default:

--- a/xsqlvar_test.go
+++ b/xsqlvar_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"database/sql/driver"
 	"math"
-  "math/big"
+	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,13 +81,42 @@ func TestScaledIntValue(t *testing.T) {
 		{"positive scale 3", 3, 7, "7000"},
 		{"negative scale -3", -3, 1234, "1.234"},
 		{"negative scale -2", -2, 50, "0.50"},
+		{"positive scale at cap 38", 38, 5, "500000000000000000000000000000000000000"},
+		{"very negative scale routes to scientific, no huge allocation", -1_000_000, 5, "5E-1000000"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			x := &xSQLVAR{sqlscale: tt.sqlscale}
-			got := x.scaledIntValue(tt.input)
+			got, err := x.scaledIntValue(tt.input)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestScaledIntValue_ScaleOutOfRange(t *testing.T) {
+	// sqlscale is server-controlled; a value above the legitimate NUMERIC/
+	// DECIMAL maximum (38) must be rejected before it drives an unbounded
+	// big.Int.Exp(10, sqlscale) allocation, rather than hanging or OOMing.
+	tests := []struct {
+		name     string
+		sqlscale int
+	}{
+		{"one above cap", maxDecimalScale + 1},
+		{"absurdly large", 1 << 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := &xSQLVAR{sqlscale: tt.sqlscale}
+			got, err := x.scaledIntValue(5)
+			if err == nil {
+				t.Fatalf("expected error for out-of-range scale %d, got value %v", tt.sqlscale, got)
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("unexpected error: %v", err)
+			}
 		})
 	}
 }
@@ -137,7 +167,8 @@ func TestScaledIntValueTrailingZeros(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			x := &xSQLVAR{sqlscale: tt.sqlscale}
-			got := x.scaledIntValue(tt.input)
+			got, err := x.scaledIntValue(tt.input)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -251,6 +282,32 @@ func TestValueInt128WithScale(t *testing.T) {
 	}
 }
 
+func TestValueInt128_ScaleOutOfRange(t *testing.T) {
+	// sqlscale is server-controlled; the INT128 positive-scale branch has its
+	// own big.Int.Exp(10, sqlscale) call (separate from scaledIntValue, which
+	// only covers SHORT/LONG/INT64) and must be capped the same way.
+	tests := []struct {
+		name     string
+		sqlscale int
+	}{
+		{"one above cap", maxDecimalScale + 1},
+		{"absurdly large", 1 << 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := &xSQLVAR{sqltype: SQL_TYPE_INT128, sqlscale: tt.sqlscale}
+			got, err := x.value(int128Bytes(big.NewInt(5)), "", "")
+			if err == nil {
+				t.Fatalf("expected error for out-of-range scale %d, got value %v", tt.sqlscale, got)
+			}
+			if !strings.Contains(err.Error(), "out of range") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValuePositiveScale(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -307,7 +364,8 @@ func TestScaledIntValuePositiveOverflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			x := &xSQLVAR{sqlscale: tt.sqlscale}
-			got := x.scaledIntValue(tt.input)
+			got, err := x.scaledIntValue(tt.input)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -331,7 +389,8 @@ func TestScaledIntValuePrecisionLoss(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			x := &xSQLVAR{sqlscale: tt.sqlscale}
-			got := x.scaledIntValue(tt.input)
+			got, err := x.scaledIntValue(tt.input)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
this branch bundles the wire-protocol length-validation hardening pass for the Firebird driver, closing out a DoS-class vulnerability surface.

every wire-parse site that trusted a server-supplied length, count, or index before slicing a buffer or sizing an allocation is now validated.

a few real bugs the hardening itself introduced or left behind were found and fixed.

# PROBLEM
- a malicious or compromised Firebird server (or a MITM) could previously send a crafted length/count/scale to crash the client (slice/index panics) or exhaust memory/CPU (unbounded allocation from an absurd NUMERIC scale or buffer size);
- the follow-up fixes close gaps where a hostile or merely malformed response could still crash the client or leave a corrupted connection silently pooled for reuse.

# SOLUTION
- bounds-checked server-claimed lengths/counts before every slice or allocation: the status vector, BLOB segment reads, event buffers, describe-vars/xsqlda parsing, service-info streams, the SRP/connect handshake, and fetch row counts;
- capped the NUMERIC/DECIMAL scale exponent (`maxDecimalScale = 38`) before it drives a big.Int.Exp call;
- fixed a `parse_xsqlda` panic on a truncated/hostile `Prepare` response;
- fixed a fetch-path gap where a desynced connection could be returned to the pool instead of evicted;
- wrapped a previously-unwrapped scale-overflow error so it correctly poisons the connection;
- fixed a masked I/O error in opFetchResponse that hid a dead socket behind a generic error;
- simplified ~30 comments this hardening pass added.
