### PR TITLE
fix: don't panic in parseDSN when the DSN has no database path

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -38,6 +38,7 @@ type firebirdDsn struct {
 }
 
 var ErrDsnUserUnknown = errors.New("User unknown")
+var ErrDsnDbNameUnknown = errors.New("Database name unknown")
 
 func newFirebirdDsn() *firebirdDsn {
 	return &firebirdDsn{options: make(map[string]string)}
@@ -64,13 +65,16 @@ func parseDSN(dsns string) (*firebirdDsn, error) {
 		dsn.addr += ":3050"
 	}
 	dsn.dbName = u.Path
-	if !strings.ContainsRune(dsn.dbName[1:], '/') {
+	if len(dsn.dbName) > 1 && !strings.ContainsRune(dsn.dbName[1:], '/') {
 		dsn.dbName = dsn.dbName[1:]
 	}
 
 	//Windows Path
-	if strings.ContainsRune(dsn.dbName[2:], ':') {
+	if len(dsn.dbName) > 2 && strings.ContainsRune(dsn.dbName[2:], ':') {
 		dsn.dbName = dsn.dbName[1:]
+	}
+	if dsn.dbName == "" || dsn.dbName == "/" {
+		return nil, ErrDsnDbNameUnknown
 	}
 
 	m, _ := url.ParseQuery(u.RawQuery)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1,0 +1,82 @@
+/*******************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2013-2020 Hajime Nakagami
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+package firebirdsql
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestParseDSNValidPaths covers the shapes that must keep parsing exactly as
+// before (guarding the slicing must not change valid results).
+func TestParseDSNValidPaths(t *testing.T) {
+	cases := []struct {
+		dsn    string
+		dbName string
+	}{
+		{"user:password@localhost:3050/dbname", "dbname"},
+		{"user:password@localhost/dbname", "dbname"},
+		{"user:password@localhost:3050/C:/db.fdb", "C:/db.fdb"},
+		{"user:password@localhost:3050/path/to/db.fdb", "/path/to/db.fdb"}, // multi-segment POSIX keeps the leading slash (existing behavior)
+	}
+	for _, c := range cases {
+		dsn, err := parseDSN(c.dsn)
+		if err != nil {
+			t.Errorf("parseDSN(%q): %v", c.dsn, err)
+			continue
+		}
+		if dsn.dbName != c.dbName {
+			t.Errorf("parseDSN(%q).dbName = %q, want %q", c.dsn, dsn.dbName, c.dbName)
+		}
+	}
+}
+
+// TestParseDSNEmptyPathNoPanic: a DSN with an empty (or "/"-only) database
+// path used to panic with "slice bounds out of range" in the unguarded
+// dsn.dbName[1:] / dsn.dbName[2:] slicing (found via database/sql:
+// sql.Open + Query panic before any connection attempt). It must return a
+// clean error instead.
+func TestParseDSNEmptyPathNoPanic(t *testing.T) {
+	cases := []string{
+		"user:password@localhost:3050/?charset=UTF8", // Path="/" + query
+		"user:password@localhost:3050/",              // Path="/"
+		"user:password@localhost:3050",               // no path at all
+		"user:password@localhost",                    // bare host
+	}
+	for _, dsn := range cases {
+		func() {
+			// parseDSN used to panic here; recover so the failure message
+			// names the offending DSN instead of killing the test binary.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("parseDSN(%q) panicked: %v", dsn, r)
+				}
+			}()
+			_, err := parseDSN(dsn)
+			if !errors.Is(err, ErrDsnDbNameUnknown) {
+				t.Errorf("parseDSN(%q) error = %v, want ErrDsnDbNameUnknown", dsn, err)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
## Problem

`parseDSN` slices `dsn.dbName` unconditionally (`dsn.dbName[1:]` and `dsn.dbName[2:]`) while normalizing the database path. Any DSN whose database path is empty or `"/"`-only panics with `slice bounds out of range` inside `driver.Open` — before any network I/O — killing the calling process:

```
panic: runtime error: slice bounds out of range [2:0]
    github.com/nakagami/firebirdsql.parseDSN (dsn.go)
```

All of these panic today (verified on master, Go 1.25, no server required — the panic happens before any connection attempt):

| DSN | `url.Parse` result | panic |
|---|---|---|
| `user:password@localhost:3050/?charset=UTF8` | `Path = "/"` | `[2:0]` |
| `user:password@localhost:3050/` | `Path = "/"` | `[2:0]` |
| `user:password@localhost:3050` | `Path = ""` | `[1:0]` |
| `user:password@localhost` | `Path = ""` | `[1:0]` |

Reproducer through `database/sql` (recovers the panic; without the recover it is a process crash):

```go
db, _ := sql.Open("firebirdsql", "user:password@localhost:3050/?charset=UTF8")
db.Query("SELECT 1") // panics in driver.Open → parseDSN
```

This is easy to hit from config-driven applications — a blank database path, or a URL like `firebird://user:pass@host:3050/?x=1`.

## Fix

- Bounds-check both slicing expressions.
- When nothing remains after normalization (empty path or `"/"`-only), return a new sentinel error `ErrDsnDbNameUnknown` ("Database name unknown"), mirroring the existing `ErrDsnUserUnknown`, instead of panicking or proceeding with an unusable connection target.

No behavior change for valid DSNs — `dsn_test.go` pins the existing results for Windows (`C:/db.fdb`), single-segment, and multi-segment POSIX paths.

## Testing

- `go test -run TestParseDSN -v .` — fails with the exact panics above on master; passes with the fix (4 empty-path cases assert `errors.Is(err, ErrDsnDbNameUnknown)`, 4 valid-shape cases assert unchanged `dbName` results).
- `go test ./...` — 74 failures before and after the change, identical; all are `dial tcp [::1]:3050: connectex: ...` (the suite expects a live Firebird + `EMPLOYEE` database on 3050, which this environment doesn't have). No new failures introduced.