### PR TITLE
fix: decode statement record counts without fixed offsets

### DIFF
--- a/.github/workflows/test_record_counts.yml
+++ b/.github/workflows/test_record_counts.yml
@@ -1,0 +1,17 @@
+name: Record counts compatibility
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  records:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        firebird: ['2.5.9', '3.0.10', '4.0.6', '5.0.0', '5.0.4']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Record counts regressions (Go 1.22)
+        env:
+          TEST_PATTERN: TestStatementRecords
+        run: scripts/test-trace-matrix.sh '${{ matrix.firebird }}'

--- a/RECORD_COUNTS.md
+++ b/RECORD_COUNTS.md
@@ -1,0 +1,87 @@
+# Statement record counts
+
+`RowsAffected` now decodes the existing `isc_info_sql_records` response by item
+tags and unsigned little-endian lengths. It no longer assumes fixed offsets or
+adds three 32-bit counters before converting their sum to 64 bits. No additional
+server requests are made. The successful result has the same size and allocation
+behavior as before; parsing valid metadata allocates no memory.
+
+The internal typed record model distinguishes an absent records block (normal
+for DDL) from four known zero counts. Unknown TLV items are skipped by length;
+missing or duplicate record counts, malformed lengths, missing terminators,
+truncation/error markers, negative counts and overflowing totals are rejected.
+The decoder accepts the signed four/eight-byte encoding used by `INF_convert`.
+Selected counts remain separate from inserted/updated/deleted counts. These are
+statement counters, not a promise to include all effects of triggers or nested
+procedures, and not a count of distinct business objects.
+
+Execution has already succeeded when this metadata is decoded. A malformed count
+therefore returns an error from `Result.RowsAffected()`, while `Exec` retains its
+successful outcome and performs the existing autocommit step. This error is never
+`driver.ErrBadConn` and never triggers a SQL retry. Network/transaction failures
+in the pre-existing execution path are outside this decoder change.
+
+The public driver API is unchanged. This is the records-decoder portion of the
+broader diagnostics proposal; it does not add observer callbacks, connection IDs,
+capability discovery, plan retrieval, a Trace parser, or a Profiler controller.
+There is no dependency on OpenTelemetry or Firebird 5 packages. The separate
+Trace lifecycle proposal is [PR #286](https://github.com/nakagami/firebirdsql/pull/286).
+Both PRs are independently based on upstream master `8d1f017`.
+
+The encoding and nesting were checked against Firebird's
+[`INF_convert` and `INF_request_info`](https://github.com/FirebirdSQL/firebird/blob/v5.0.3/src/jrd/inf.cpp)
+and [`isc_info_sql_records` handling](https://github.com/FirebirdSQL/firebird/blob/v5.0.3/src/dsql/dsql.cpp).
+An initial live test used INSERT/SELECT against the same table; it was corrected
+to select from `RDB$DATABASE` because Firebird 2.5 has a documented
+[unstable insert cursor](https://www.firebirdsql.org/file/documentation/chunk/en/refdocs/fblangref25/fblangref25-dml-insert.html).
+The test now uses the same finite workload on every version, without a skip.
+
+## Checks
+
+- Unit tests cover ordering, unknown items, four/eight-byte widths, counts above
+  32 bits, absent/zero distinction, every truncated prefix, duplicate fields,
+  signed-value rejection and sum overflow.
+- A wire-level regression simulates successful DML followed by malformed counts.
+  It verifies exactly one execution, one existing info request and one existing
+  commit-retaining (in autocommit mode). Explicit-transaction mode sends no commit.
+- The live test verifies DDL, insert, insert/select, update, zero-row update,
+  delete, repeated prepared execution and rollback on one pinned connection.
+- `FuzzStatementRecords`: 1,288,995 executions in 11 seconds without failure.
+- Apple M4 / Go 1.27.0: decoder benchmark 13.28–13.62 ns/op, 0 B/op, 0 allocs/op
+  (three runs). This is a decoder microbenchmark, not a server latency claim.
+
+To repeat the focused tests against an isolated server:
+
+```sh
+TMPDIR=/tmp FIREBIRD_TEST_SERVER_ADDR=localhost:3050 \
+  go test -race -run TestStatementRecords -count=1 ./...
+go test -run '^$' -fuzz '^FuzzStatementRecords$' -fuzztime=10s ./...
+go test -run '^$' -bench BenchmarkStatementRecords -benchmem ./...
+```
+
+Use the existing `ISC_USER`/`ISC_PASSWORD` test settings as necessary. Full-suite
+Docker runs should put the test runner in the server's network namespace, so the
+auxiliary port used by the existing event tests is reachable. The matrix runner
+shared with PR #286 provides this setup (the script is identical in both PRs).
+The dedicated Go 1.22 CI matrix runs these regressions on all five server versions;
+the tests also run in the existing Firebird 2.5 and 3 CI jobs. HQBird/vendor servers and performance under production
+load have not been verified.
+
+Verified locally on 2026-09-05:
+
+| Server | Validation |
+| --- | --- |
+| LI-V2.5.9.27139 | Full suite with race detector, pass after fixture correction |
+| LI-V3.0.10.33601 | Full suite with race detector, pass |
+| LI-V4.0.6.3221 | Full suite with race detector, pass |
+| LI-V5.0.4.1812 | Full suite with race detector, pass |
+| LI-V5.0.3.1683 | Focused live records test with race detector, pass |
+| LI-V5.0.0.1306 | Focused live/unit records tests with race detector, pass on Go 1.22 |
+
+Full runs used Go 1.26.3 Linux amd64 and returned PASS with the existing
+version/fixture skips. These include features unsupported on older engines,
+external EMPLOYEE fixtures, optional performance tests, and authentication/limbo
+fixtures absent from the images. `go vet -composites=false ./...` passes;
+default vet reports the existing unkeyed `sql.TxOptions` literal in
+`driver_go18_test.go`. Neither passing these tests nor decoding wide counters
+proves support for every server configuration or every nested PSQL counting scope.

--- a/result.go
+++ b/result.go
@@ -35,3 +35,14 @@ func (res *firebirdsqlResult) LastInsertId() (int64, error) {
 func (res *firebirdsqlResult) RowsAffected() (int64, error) {
 	return res.affectedRows, nil
 }
+
+// Only malformed metadata needs extra storage; the normal result keeps its
+// existing size and allocation behavior.
+type firebirdsqlResultCountError struct {
+	firebirdsqlResult
+	err error
+}
+
+func (res *firebirdsqlResultCountError) RowsAffected() (int64, error) {
+	return 0, res.err
+}

--- a/scripts/test-trace-matrix.sh
+++ b/scripts/test-trace-matrix.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Isolated live matrix. Requires Docker. No external database is contacted.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+root="$PWD"
+version="${1:-5.0.4}"
+case "$version" in
+  2.5.9) image='jacobalberty/firebird@sha256:6efd02fc057818e3f9b5da77d56997bafd883a582e666cf7e5371aefec7f84ac' ;;
+  3.0.10) image='jacobalberty/firebird@sha256:765807beb822a182205259dbcadf5b06df66fa6c51a746ac67d48deb981026d7' ;;
+  4.0.6) image='firebirdsql/firebird@sha256:1bef0d3c18c2e1dc3e3de6a2fe7d9e79dbe27e534f95b23915846fadecd8f5dd' ;;
+  5.0.0) image='firebirdsql/firebird@sha256:e75a3b245fd5a88c6f464c63f85604b84aa0dc3b8aa1f0afaf7abe25a09419db' ;;
+  5.0.3) image='firebirdsql/firebird@sha256:d1e15bdcc0da40bf5e8af24ba6ba1d14b23d0a43fd21faa4ec8b2089feefb3b8' ;;
+  5.0.4) image='firebirdsql/firebird@sha256:1529560400fc7847f015c57fc9d70729c44d9a9d8f9000df19c5ce1950b4c202' ;;
+  *) echo "unsupported matrix version: $version" >&2; exit 2 ;;
+esac
+name="firebirdsql-trace-test-$$"
+trap 'docker rm -fv "$name" >/dev/null 2>&1 || true' EXIT
+# Published ports are unnecessary: the test runner shares the server network,
+# including the dynamically allocated auxiliary port used by existing tests.
+docker run -d --name "$name" --platform linux/amd64 \
+  -e ISC_PASSWORD=masterkey -e FIREBIRD_ROOT_PASSWORD=masterkey "$image" >/dev/null
+if [[ "$version" == 3.0.10 ]]; then
+  for attempt in {1..30}; do
+    if docker exec "$name" test -f /firebird/etc/firebird.conf; then break; fi
+    sleep 1
+  done
+  docker exec "$name" sed -i 's/^DatabaseAccess =.*/DatabaseAccess = Full/' /firebird/etc/firebird.conf
+  docker restart "$name" >/dev/null
+fi
+# Bash's TCP probe is available in the Go image, including Go 1.22.
+docker run --rm --platform linux/amd64 --network "container:$name" \
+  -v "$root:/work:ro" -v firebirdsql-matrix-mod:/go/pkg/mod \
+  -v firebirdsql-matrix-build:/root/.cache/go-build -w /work \
+  -e FIREBIRDSQL_TRACE_TEST=1 -e "TEST_PATTERN=${TEST_PATTERN:-.}" \
+  "golang:${GO_VERSION:-1.22}-bookworm" bash -c '
+    for attempt in {1..60}; do
+      if (echo >/dev/tcp/127.0.0.1/3050) 2>/dev/null; then break; fi
+      sleep 1
+    done
+    go test -race -v ./... -run "$TEST_PATTERN" -count=1 -timeout 15m
+  '

--- a/statement.go
+++ b/statement.go
@@ -243,21 +243,19 @@ func (stmt *firebirdsqlStmt) exec(ctx context.Context, args []driver.Value) (res
 		return
 	}
 
+	records, countErr := decodeStatementRecords(buf)
 	var rowcount int64
-	if len(buf) >= 32 {
-		if stmt.stmtType == isc_info_sql_stmt_select ||
-			stmt.stmtType == isc_info_sql_stmt_select_for_upd {
-			rowcount = int64(bytes_to_int32(buf[20:24]))
-		} else {
-			rowcount = int64(bytes_to_int32(buf[27:31]) + bytes_to_int32(buf[6:10]) + bytes_to_int32(buf[13:17]))
-		}
+	if countErr == nil {
+		rowcount, countErr = records.rowsAffected(stmt.stmtType)
+	}
+	// Execution already succeeded. Invalid count metadata belongs to RowsAffected,
+	// never to Exec's error (and must not prevent the existing autocommit).
+	if countErr != nil {
+		result = &firebirdsqlResultCountError{err: countErr}
 	} else {
-		rowcount = 0
+		result = &firebirdsqlResult{affectedRows: rowcount}
 	}
 
-	result = &firebirdsqlResult{
-		affectedRows: rowcount,
-	}
 	if stmt.fc.tx.isAutocommit {
 		if cerr := stmt.fc.tx.commitRetainging(); cerr != nil {
 			return result, cerr

--- a/statement_records.go
+++ b/statement_records.go
@@ -1,0 +1,124 @@
+package firebirdsql
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+)
+
+var errStatementRecords = errors.New("firebirdsql: invalid statement record counts")
+var errStatementRecordsOverflow = errors.New("firebirdsql: statement record count overflow")
+
+// statementRecords contains only counts supplied by isc_info_sql_records.
+// They describe the outer statement, not all trigger/procedure modifications.
+// DDL may omit the records item entirely; available distinguishes that from zero.
+type statementRecords struct {
+	selected, inserted, updated, deleted int64
+	available                            bool
+}
+
+// nextStatementInfo reads the common tag/unsigned-16-bit-length/value encoding.
+// Structural markers are single bytes. Bytes following isc_info_end may be
+// unused response-buffer padding and are not interpreted as additional items.
+func nextStatementInfo(buf []byte) (tag byte, value, rest []byte, err error) {
+	if len(buf) == 0 {
+		return 0, nil, nil, errStatementRecords
+	}
+	tag = buf[0]
+	if tag == isc_info_end {
+		return tag, nil, nil, nil
+	}
+	if tag == isc_info_truncated || tag == isc_info_error || len(buf) < 3 {
+		return 0, nil, nil, errStatementRecords
+	}
+	size := int(binary.LittleEndian.Uint16(buf[1:3]))
+	if size > len(buf)-3 {
+		return 0, nil, nil, errStatementRecords
+	}
+	return tag, buf[3 : 3+size], buf[3+size:], nil
+}
+
+func decodeStatementRecords(buf []byte) (records statementRecords, err error) {
+	for {
+		tag, value, rest, e := nextStatementInfo(buf)
+		if e != nil {
+			return statementRecords{}, e
+		}
+		if tag == isc_info_end {
+			return records, nil
+		}
+		if tag == isc_info_sql_records {
+			if records.available {
+				return statementRecords{}, errStatementRecords
+			}
+			records, e = decodeRecordItems(value)
+			if e != nil {
+				return statementRecords{}, e
+			}
+		}
+		buf = rest
+	}
+}
+
+func decodeRecordItems(buf []byte) (records statementRecords, err error) {
+	var seen byte
+	for {
+		tag, value, rest, e := nextStatementInfo(buf)
+		if e != nil {
+			return statementRecords{}, e
+		}
+		if tag == isc_info_end {
+			if seen != 15 {
+				return statementRecords{}, errStatementRecords
+			}
+			records.available = true
+			return records, nil
+		}
+		if tag >= isc_info_req_select_count && tag <= isc_info_req_delete_count {
+			bit := byte(1 << (tag - isc_info_req_select_count))
+			if seen&bit != 0 {
+				return statementRecords{}, errStatementRecords
+			}
+			seen |= bit
+			// INF_convert uses signed little-endian SLONG or SINT64. Values above
+			// MAX_SLONG are encoded in eight bytes, not truncated to four bytes.
+			var count int64
+			switch len(value) {
+			case 4:
+				count = int64(int32(binary.LittleEndian.Uint32(value)))
+			case 8:
+				count = int64(binary.LittleEndian.Uint64(value))
+			default:
+				return statementRecords{}, errStatementRecords
+			}
+			if count < 0 {
+				return statementRecords{}, errStatementRecordsOverflow
+			}
+			switch tag {
+			case isc_info_req_select_count:
+				records.selected = count
+			case isc_info_req_insert_count:
+				records.inserted = count
+			case isc_info_req_update_count:
+				records.updated = count
+			case isc_info_req_delete_count:
+				records.deleted = count
+			}
+		}
+		buf = rest
+	}
+}
+
+func (r statementRecords) rowsAffected(stmtType int32) (int64, error) {
+	if stmtType == isc_info_sql_stmt_select || stmtType == isc_info_sql_stmt_select_for_upd {
+		return r.selected, nil
+	}
+	if r.inserted > math.MaxInt64-r.updated {
+		return 0, errStatementRecordsOverflow
+	}
+	count := r.inserted + r.updated
+	if count > math.MaxInt64-r.deleted {
+		return 0, errStatementRecordsOverflow
+	}
+	return count + r.deleted, nil
+}

--- a/statement_records_test.go
+++ b/statement_records_test.go
@@ -1,0 +1,239 @@
+package firebirdsql
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"math"
+	"net"
+	"testing"
+	"time"
+)
+
+func recordItem(tag byte, n int64, width int) []byte {
+	b := make([]byte, 3+width)
+	b[0] = tag
+	binary.LittleEndian.PutUint16(b[1:], uint16(width))
+	if width == 4 {
+		binary.LittleEndian.PutUint32(b[3:], uint32(n))
+	} else if width == 8 {
+		binary.LittleEndian.PutUint64(b[3:], uint64(n))
+	}
+	return b
+}
+func recordBlock(items ...[]byte) []byte {
+	var data []byte
+	for _, item := range items {
+		data = append(data, item...)
+	}
+	data = append(data, isc_info_end)
+	b := []byte{isc_info_sql_records, byte(len(data)), byte(len(data) >> 8)}
+	b = append(b, data...)
+	return append(b, isc_info_end)
+}
+func typicalRecords(width int) []byte {
+	return recordBlock(recordItem(15, 3, width), recordItem(16, 5, width), recordItem(13, 7, width), recordItem(14, 11, width))
+}
+
+func TestStatementRecordsOrderingAndWidths(t *testing.T) {
+	for _, width := range []int{4, 8} {
+		for _, order := range [][4]byte{{13, 14, 15, 16}, {16, 13, 15, 14}, {14, 16, 13, 15}} {
+			items := [][]byte{{90, 1, 0, 99}} // unknown nested TLV is skipped
+			for _, tag := range order {
+				items = append(items, recordItem(tag, int64(tag), width))
+			}
+			b := append([]byte{91, 2, 0, 1, 2}, recordBlock(items...)...)
+			r, err := decodeStatementRecords(b)
+			if err != nil || !r.available || r.selected != 13 || r.inserted != 14 || r.updated != 15 || r.deleted != 16 {
+				t.Fatalf("%+v %v", r, err)
+			}
+			if count, e := r.rowsAffected(isc_info_sql_stmt_insert); e != nil || count != 45 {
+				t.Fatalf("count=%d err=%v", count, e)
+			}
+			if count, e := r.rowsAffected(isc_info_sql_stmt_select); e != nil || count != 13 {
+				t.Fatalf("select=%d err=%v", count, e)
+			}
+		}
+	}
+	b := recordBlock(recordItem(13, 0, 4), recordItem(14, math.MaxInt32, 4), recordItem(15, math.MaxInt32, 4), recordItem(16, 1<<40, 8))
+	r, err := decodeStatementRecords(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := r.rowsAffected(isc_info_sql_stmt_update)
+	if err != nil || n != 2*int64(math.MaxInt32)+(1<<40) {
+		t.Fatalf("wide count=%d %v", n, err)
+	}
+}
+
+func TestStatementRecordsMalformed(t *testing.T) {
+	valid := typicalRecords(4)
+	for i := 0; i < len(valid); i++ {
+		if _, err := decodeStatementRecords(valid[:i]); err == nil {
+			t.Fatalf("accepted prefix %d", i)
+		}
+	}
+	for _, b := range [][]byte{
+		{isc_info_truncated}, {isc_info_error, 0, 0},
+		recordBlock(recordItem(13, 0, 4)),                       // missing required items
+		recordBlock(recordItem(13, 0, 4), recordItem(13, 0, 4)), // duplicate
+		recordBlock(recordItem(13, -1, 4)), recordBlock(recordItem(13, -1, 8)),
+		recordBlock(recordItem(13, 0, 3)),
+		append(append([]byte{}, valid[:len(valid)-1]...), valid...), // duplicate records block
+	} {
+		if _, err := decodeStatementRecords(b); err == nil {
+			t.Fatalf("accepted %v", b)
+		}
+	}
+	r := statementRecords{inserted: math.MaxInt64, updated: 1}
+	if _, err := r.rowsAffected(isc_info_sql_stmt_insert); !errors.Is(err, errStatementRecordsOverflow) {
+		t.Fatalf("sum overflow=%v", err)
+	}
+	r = statementRecords{inserted: math.MaxInt64, deleted: 1}
+	if _, err := r.rowsAffected(isc_info_sql_stmt_delete); !errors.Is(err, errStatementRecordsOverflow) {
+		t.Fatalf("sum overflow=%v", err)
+	}
+}
+
+func TestStatementRecordsAbsentVersusZero(t *testing.T) {
+	r, err := decodeStatementRecords([]byte{isc_info_end})
+	if err != nil || r.available {
+		t.Fatalf("absent=%+v %v", r, err)
+	}
+	n, err := r.rowsAffected(isc_info_sql_stmt_ddl)
+	if err != nil || n != 0 {
+		t.Fatalf("DDL count=%d %v", n, err)
+	}
+	r, err = decodeStatementRecords(recordBlock(recordItem(13, 0, 4), recordItem(14, 0, 4), recordItem(15, 0, 4), recordItem(16, 0, 4)))
+	if err != nil || !r.available {
+		t.Fatalf("zero=%+v %v", r, err)
+	}
+}
+
+type recordDeadlineConn struct{ net.Conn }
+
+func (recordDeadlineConn) SetDeadline(time.Time) error { return nil }
+
+func TestStatementRecordsInvalidMetadataKeepsExecSuccess(t *testing.T) {
+	for _, autocommit := range []bool{false, true} {
+		var frames acceptFrame
+		frames.opResponseFrame(0, nil)                                    // successful DML
+		frames.opResponseFrame(0, []byte{isc_info_sql_records, 255, 255}) // malformed counts
+		if autocommit {
+			frames.opResponseFrame(0, nil)
+		} // commit-retaining ack
+		wp := testProtocol(frames.bytes())
+		wp.conn.conn = recordDeadlineConn{}
+		var written bytes.Buffer
+		wp.conn.writer = bufio.NewWriter(&written)
+		fc := &firebirdsqlConn{wp: wp, isAutocommit: autocommit}
+		fc.tx = &firebirdsqlTx{fc: fc, isAutocommit: autocommit, transHandle: 1}
+		stmt := &firebirdsqlStmt{fc: fc, stmtHandle: 2, stmtType: isc_info_sql_stmt_insert}
+		result, err := stmt.exec(context.Background(), nil)
+		if err != nil || result == nil {
+			t.Fatalf("successful DML turned into an error: %v", err)
+		}
+		if _, err = result.RowsAffected(); !errors.Is(err, errStatementRecords) {
+			t.Fatalf("count error lost: %v", err)
+		}
+		// Exactly one execute and one info request; autocommit still occurs once.
+		b := written.Bytes()
+		wantLen := 48
+		if autocommit {
+			wantLen += 8
+		}
+		if len(b) != wantLen || binary.BigEndian.Uint32(b[:4]) != op_execute || binary.BigEndian.Uint32(b[24:28]) != op_info_sql {
+			t.Fatalf("unexpected command sequence: %x", b)
+		}
+		if autocommit && binary.BigEndian.Uint32(b[48:52]) != op_commit_retaining {
+			t.Fatalf("commit skipped: %x", b)
+		}
+	}
+}
+
+func TestStatementRecordsLive(t *testing.T) {
+	db, err := sql.Open("firebirdsql_createdb", GetTestDSN("record_counts_"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	for _, tc := range []struct {
+		sql   string
+		count int64
+	}{
+		{"CREATE TABLE RECORD_COUNTS (ID INTEGER)", 0},
+		{"INSERT INTO RECORD_COUNTS VALUES (1)", 1},
+		{"INSERT INTO RECORD_COUNTS SELECT 2 FROM RDB$DATABASE", 1},
+		{"UPDATE RECORD_COUNTS SET ID=ID+1", 2},
+		{"UPDATE RECORD_COUNTS SET ID=0 WHERE ID<0", 0},
+		{"DELETE FROM RECORD_COUNTS", 2},
+	} {
+		result, e := conn.ExecContext(context.Background(), tc.sql)
+		if e != nil {
+			t.Fatal(e)
+		}
+		count, e := result.RowsAffected()
+		if e != nil || count != tc.count {
+			t.Fatalf("%s: count=%d want=%d err=%v", tc.sql, count, tc.count, e)
+		}
+	}
+	tx, err := conn.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := tx.Prepare("INSERT INTO RECORD_COUNTS VALUES (?)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		result, e := stmt.Exec(i)
+		if e != nil {
+			t.Fatal(e)
+		}
+		n, e := result.RowsAffected()
+		if e != nil || n != 1 {
+			t.Fatalf("prepared count=%d %v", n, e)
+		}
+	}
+	_ = stmt.Close()
+	if err = tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	var remaining int
+	if err = conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM RECORD_COUNTS").Scan(&remaining); err != nil || remaining != 0 {
+		t.Fatalf("rollback changed: %d %v", remaining, err)
+	}
+}
+
+func FuzzStatementRecords(f *testing.F) {
+	f.Add(typicalRecords(4))
+	f.Add(typicalRecords(8))
+	f.Add([]byte{isc_info_end})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		r, err := decodeStatementRecords(b)
+		if err == nil {
+			n, e := r.rowsAffected(isc_info_sql_stmt_insert)
+			if e == nil && n < 0 {
+				t.Fatal("negative count")
+			}
+		}
+	})
+}
+
+func BenchmarkStatementRecords(b *testing.B) {
+	buf := typicalRecords(4)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := decodeStatementRecords(buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
RowsAffected currently reads fixed byte offsets and adds three int32 counters before converting the sum to int64. Reordered items or eight-byte counts produce incorrect results, and large totals can overflow.

Decode the existing isc_info_sql_records response using its nested TLV encoding, signed little-endian four/eight-byte counters, explicit field presence and checked sums. Unknown items are skipped by length; truncation, malformed/duplicate/missing fields and overflow are reported. DDL's absent records block retains its zero RowsAffected result.

Execution has already succeeded when count metadata is parsed. Malformed metadata therefore reports through Result.RowsAffected, preserving successful Exec, its existing autocommit and exactly-once execution. The normal result size/allocation is unchanged and the decoder makes no allocations or new server requests. This is the records portion of a larger diagnostics proposal; no new OTel/FB5 dependency or full observer/capability/profiler API is introduced.

Validation:
- Full suite with `-race`: LI-V2.5.9.27139, LI-V3.0.10.33601, LI-V4.0.6.3221, LI-V5.0.4.1812; PASS with existing version/fixture skips (Go 1.26.3 Linux amd64).
- Focused live tests: LI-V5.0.3.1683 and LI-V5.0.0.1306; Go 1.22 isolated matrix runner also passed on 5.0.0.
- Wire regression verifies successful DML + malformed count metadata sends exactly one execution, the existing info request, and the existing commit-retaining; explicit transactions send no commit.
- Fuzz: 1,288,995 executions without failure. Decoder benchmark: 13.28–13.62 ns/op, 0 B/op, 0 allocs/op on Apple M4 (microbenchmark only).
- Dedicated Go 1.22 CI matrix for FB2.5/3/4/5.0.0/5.0.4.

This PR and Trace lifecycle PR #286 are independently based on master 8d1f017. The small Docker matrix script is identical in both, so either can be reviewed/merged first. RECORD_COUNTS.md records sources, reproducible commands and limitations. The initial self-insert test workload was corrected for Firebird 2.5's documented unstable cursor; the same finite test now runs on all versions. HQBird, production performance, full typed statement metadata and Profiler remain outside this PR.

Combined verification: merged #286 and #287 locally without conflicts and ran Trace/service/record-count regressions together with `-race` on Firebird 2.5.9, 3.0.10, 4.0.6 and 5.0.4; all passed.
